### PR TITLE
Open file:// links locally

### DIFF
--- a/source/js/utils/links.js
+++ b/source/js/utils/links.js
@@ -14,7 +14,16 @@ exports.trapLinks = function(doc) {
 		// "tc-tiddlylink" is for TW5, "tiddlyLink" for TWC
 		var link = $tw.desktop.utils.dom.findParentWithTag(event.target,"a");
 		if(link && !$tw.desktop.utils.dom.hasClass(link,"tc-tiddlylink tw-tiddlylink tiddlyLink")) {
-			$tw.desktop.gui.Shell.openExternal(link.getAttribute("href"));
+			var href = link.getAttribute("href");
+			if (doc.location.protocol === "file:" && href.substr(0, 5) === 'file:') {
+				// File links - open as local files
+				var locationPathParts = doc.location.pathname.split("/").slice(0,-1).map(decodeURIComponent),
+					filePathParts = href.substr(5).split(/[\\\/]/mg).map(decodeURIComponent),
+					url = locationPathParts.join('/') + '/' + filePathParts.join('/');
+				$tw.desktop.gui.Shell.openItem(url);
+			} else {
+				$tw.desktop.gui.Shell.openExternal(href);
+			}
 			event.preventDefault();
 			event.stopPropagation();
 			return false;


### PR DESCRIPTION
The previous approach uses the `nwjs` method `Shell.openExternal` to open file URLs. That does not work, and simply becomes a no-op.

This change modifies that to use `Shell.openItem` for file:// URLs instead.

I experimentally use this together with the following TW5 docparser to generally improve embedding of local files:

```js
/*\
title: $docparser.js
type: application/javascript
module-type: parser

Link to external files for easy consumption.

\*/
(function(){

/*jslint node: true, browser: true */
/*global $tw: false */
"use strict";

var DocParser = function(type,text,options) {
	var element;
	if(!options._canonical_uri) {
		element = {
			type: "element",
			tag: "span",
			text: "Binary documents must be embedded using _canonical_uri"
		};
	} else {
		element = {
			type: "element",
			tag: "a",
			attributes: {
				href: {type: "string", value: 'file:./' + options._canonical_uri},
				"class": {type: "string", value: "tc-tiddlylink-external"},
				target: {type: "string", value: "_blank"},
				rel: {type: "string", value: "noopener noreferrer"}
			},
			children: [{
				type: "text", text: unescape(options._canonical_uri)
			}]
		};
	}

	this.tree = [element];
	console.log(this.tree);
};

exports["application/vnd.openxmlformats-officedocument.wordprocessingml.document"] = DocParser;

})();
```