### PR TITLE
Allow renaming the title of the main window.

### DIFF
--- a/plugins/tiddlydesktop/settings/Settings.tid
+++ b/plugins/tiddlydesktop/settings/Settings.tid
@@ -10,6 +10,10 @@ page-title: TiddlyDesktop Settings
 
 Version {{$:/TiddlyDesktop/version}}
 
+!! Title of the WikiList Window
+
+<$edit-text tiddler="WikiListWindow" class="td-big-textarea" field="page-title" tag="input"/>
+
 !! Backups for ~TiddlyWiki 5 Wikis
 
 Backups are automatically made every time saving changes results in a file being overwritten. The previous content of the file is copied to a backup file with a filename such as `\MyData\index.html_backup\index.20150107172517000.html`.


### PR DESCRIPTION
This can be useful for people using the `--user-data-dir` parameter, as they can name work and personal wikilists separately.