### PR TITLE
Preserve symlinks when packaging macOS app

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -12,7 +12,7 @@ pushd ./output/win64
 zip -r ../tiddlydesktop-win64-v0.0.14.zip *
 popd
 pushd ./output/mac64
-zip -r ../tiddlydesktop-mac64-v0.0.14.zip *
+zip --symlinks -r ../tiddlydesktop-mac64-v0.0.14.zip *
 popd
 pushd ./output/linux32
 zip -r ../tiddlydesktop-linux32-v0.0.14.zip *


### PR DESCRIPTION
This PR adds the `--symlinks` flag to `zip` when packaging for macOS, and should resolve #104.

When `zip`ing the macOS binary, symlinks are not preserved. This leads to duplicate copies of files that are supposed to be symlinks, resulting in a huge binary size. More details here: https://github.com/Jermolene/TiddlyDesktop/issues/104#issuecomment-425748601