### PR TITLE
Made unpacking nwjs automatic in download script

### DIFF
--- a/download-nwjs.sh
+++ b/download-nwjs.sh
@@ -12,3 +12,9 @@ curl -o 'nwjs/nwjs-sdk-v0.32.4-linux-x64.tar.gz' 'https://dl.nwjs.io/v0.32.4/nwj
 curl -o 'nwjs/nwjs-sdk-v0.32.4-linux-ia32.tar.gz' 'https://dl.nwjs.io/v0.32.4/nwjs-sdk-v0.32.4-linux-ia32.tar.gz'
 curl -o 'nwjs/nwjs-sdk-v0.32.4-osx-x64.zip' 'https://dl.nwjs.io/v0.32.4/nwjs-sdk-v0.32.4-osx-x64.zip'
 
+pushd nwjs
+
+ls *.gz | xargs -n 1 tar -xvzf
+ls *.zip | xargs -n 1 unzip
+
+popd


### PR DESCRIPTION
This commit adds a step to `download-nwjs.sh` so that it unpacks the downloaded tarballs and zips for nwjs. I noticed when I was following along in `readme.md` that I got an error during build because I didn't realize that an unpack was required between steps 1 and 3.