### PR TITLE
Properly quit application from the 'Quit' option on the systray menu

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -64,8 +64,9 @@ trayMenu.append(new gui.MenuItem({
 }));
 trayMenu.append(new gui.MenuItem({
 	label: "Quit",
-	// Undocumented nw.js feature for invoking system actions:
-    selector: "closeAllWindowsQuit:"
+    click: function() {
+        gui.App.quit();
+    }
 }));
 tray.menu = trayMenu;
 


### PR DESCRIPTION
I have recently installed TiddlyDesktop and I have noticed that, when I click on the 'Quit' option in the systray menu, the application wouldn't quit. I reproduced this on both KDE and Cinnamon on a Manjaro Linux system.

After changing the menu definition as per this PR, the application quits successfully.
