### PR TITLE
Fix confirm/alert dialogs in iframes

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -11,5 +11,5 @@
         "min_height": 500
     },
     "version": "0.0.15-prerelease.2",
-    "chromium-args": "--mixed-context --enable-spell-checking --allow-file-access-from-files --allow-file-access --allow-file-cookies"
+    "chromium-args": "--mixed-context --enable-spell-checking --allow-file-access-from-files --allow-file-access --allow-file-cookies --disable-features='SuppressDifferentOriginSubframeJSDialogs'"
 }


### PR DESCRIPTION
This fixes #233 by adding a flag to Chromium which disables the "feature" of disabling alert/confirm dialogs in cross-origin iframes.