### PR TITLE
Faster wiki-list startup + cross-app drag-drop import on Linux

### DIFF
--- a/source/html/backstage-tiddler-window.html
+++ b/source/html/backstage-tiddler-window.html
@@ -3,7 +3,40 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <title>TiddlyDesktop</title>
+<style>
+.td-loading-splash {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	color: #666;
+	background: #fff;
+	z-index: 9999;
+}
+.td-loading-spinner {
+	width: 40px;
+	height: 40px;
+	border: 3px solid #eee;
+	border-top-color: #888;
+	border-radius: 50%;
+	animation: td-spin 1s linear infinite;
+	margin-bottom: 16px;
+}
+@keyframes td-spin {
+	to { transform: rotate(360deg); }
+}
+</style>
 </head>
 <body class="tc-body td-backstage-tiddler-window">
+<div class="td-loading-splash" id="td-loading-splash">
+	<div class="td-loading-spinner"></div>
+	<div>Loading TiddlyDesktop&hellip;</div>
+</div>
 </body>
 </html>

--- a/source/js/backstage-window.js
+++ b/source/js/backstage-window.js
@@ -16,6 +16,8 @@ function BackstageWindow(options) {
 	this.info = options.info || {};
 	this.tiddler = this.info.tiddler;
 	this.mustQuitOnClose = options.mustQuitOnClose;
+	this.windowLoaded = false;
+	this.rendered = false;
 	// Open the window
 	$tw.desktop.gui.Window.open("html/backstage-tiddler-window.html",{
 		id: hash.simpleHash(this.getIdentifier()),
@@ -26,6 +28,11 @@ function BackstageWindow(options) {
 		self.window_nwjs.once("loaded",self.onloaded.bind(self));
 		self.window_nwjs.on("close",self.onclose.bind(self));
 	});
+}
+
+// True when $tw has finished booting and we can render TiddlyWiki content
+function isBootComplete() {
+	return !!($tw && $tw.wiki && $tw.utils && $tw.popup && $tw.rootWidget && $tw.fakeDocument);
 }
 
 // Static method for getting the identifier for the specified info
@@ -45,29 +52,41 @@ BackstageWindow.prototype.getIdentifier = function() {
 	return BackstageWindow.getIdentifierFromInfo({tiddler: this.tiddler});
 };
 
-// Load handler for window
+// Load handler for window — the splash is visible at this point.
+// Defers the TiddlyWiki-dependent setup until boot has completed.
 BackstageWindow.prototype.onloaded = function(event) {
-	// Make $tw available in the window
+	this.windowLoaded = true;
+	// Always make $tw visible in the new window (the reference is stable
+	// across boot; boot mutates the same object)
 	this.window_nwjs.window.$tw = $tw;
-	// Show dev tools
-	// this.window_nwjs.showDevTools();
-	// Trap links
+	this.window_nwjs.show();
+	this.window_nwjs.focus();
+	this.tryRender();
+};
+
+// Render the page content once both the window has loaded AND $tw has booted.
+// Idempotent — safe to call from onloaded or from main.js after boot.
+BackstageWindow.prototype.tryRender = function() {
+	if(this.rendered) { return; }
+	if(!this.windowLoaded) { return; }
+	if(!isBootComplete()) { return; }
+	this.rendered = true;
+	// TiddlyWiki-dependent setup that used to live in onloaded
 	$tw.desktop.utils.links.trapLinks(this.window_nwjs.window.document);
-	// Handle popups
 	$tw.utils.addEventListeners(this.window_nwjs.window.document,[{
 		name: "click",
 		handlerObject: $tw.popup,
 		handlerMethod: "handleEvent"
 	}]);
-	// Show dev tools on F12
 	$tw.desktop.utils.devtools.trapDevTools(this.window_nwjs,this.window_nwjs.window.document);
-	// Add menu
 	$tw.desktop.utils.menu.createMenuBar(this.window_nwjs);
-	// Show the window
-	this.window_nwjs.show();
-	this.window_nwjs.focus();
-	// Render the window content
+	// Render the page content
 	this.renderWindow();
+	// Remove the loading splash now that real content is rendered
+	var splash = this.window_nwjs.window.document.getElementById("td-loading-splash");
+	if(splash && splash.parentNode) {
+		splash.parentNode.removeChild(splash);
+	}
 };
 
 BackstageWindow.prototype.renderWindow = function() {
@@ -112,8 +131,11 @@ BackstageWindow.prototype.changeHandler = function (changes) {
 
 // Close handler for window
 BackstageWindow.prototype.onclose = function(event) {
-	// Remove our wiki change event handler
-	$tw.wiki.removeEventListener("change",this.boundChangeHandler);
+	// Remove our wiki change event handler (may not exist if the window was
+	// closed before TiddlyWiki finished booting and rendering)
+	if($tw && $tw.wiki && this.boundChangeHandler) {
+		$tw.wiki.removeEventListener("change",this.boundChangeHandler);
+	}
 	// Close the window, remove it from the window list
 	this.windowList.handleClose(this);
 };

--- a/source/js/dragdrop.js
+++ b/source/js/dragdrop.js
@@ -1,0 +1,192 @@
+/*
+Cross-browser drag-drop import interceptor.
+
+Works around Chromium's cross-app drag-data sanitiser on Linux, which strips
+custom MIME types (text/vnd.tiddler) and most standards (text/uri-list etc.)
+when a drag crosses application boundaries. In practice only text/plain and
+text/html survive. TiddlyWiki sources publish the data:text/vnd.tiddler URI
+inside both a custom MIME and (after the upstream patch) the href of an
+anchor in text/html — this interceptor finds the URI in whichever channel
+survived and dispatches tm-import-tiddlers on the wiki's navigator widget so
+the standard $:/Import preview opens.
+
+Installed on the iframe document of each wiki-file window, and on the
+document of wiki-folder windows, by their respective host scripts.
+*/
+
+"use strict";
+
+var DATA_URI_RE = /^data:text\/vnd\.tiddler,(.*)$/i;
+
+// MIME types TiddlyWiki sources publish, plus standards Chromium sometimes
+// exposes via getData() without listing in dataTransfer.types[]. We probe
+// these explicitly so the receiver isn't tied to Chromium's enumeration.
+var PROBE_TYPES = [
+	"text/uri-list",
+	"text/x-moz-url",
+	"URL",
+	"text/vnd.tiddler",
+	"text/html",
+	"application/json",
+	"application/vnd.tiddler+json",
+	"text/json",
+	"Text",
+	"text/plain"
+];
+
+// Chromium on Linux hands text/html to JS as UTF-16LE bytes interpreted as
+// Latin-1: every "real" character is followed by a null. Detect this
+// shape and decode back to a normal JS string before pattern-matching.
+function maybeDecodeUtf16(raw) {
+	if(!raw || raw.length < 4) { return raw; }
+	var sample = Math.min(raw.length, 64),
+		nulls = 0;
+	for(var i = 1; i < sample; i += 2) {
+		if(raw.charCodeAt(i) === 0) { nulls++; }
+	}
+	if(nulls < Math.floor(sample / 2) * 0.8) { return raw; }
+	if(typeof TextDecoder !== "undefined") {
+		try {
+			var bytes = new Uint8Array(raw.length);
+			for(var k = 0; k < raw.length; k++) { bytes[k] = raw.charCodeAt(k) & 0xff; }
+			return new TextDecoder("utf-16le").decode(bytes).replace(/^﻿/, "");
+		} catch(e) {}
+	}
+	var out = "";
+	for(var j = 0; j < raw.length; j += 2) { out += raw.charAt(j); }
+	return out;
+}
+
+function tryDecodeTiddlerPayload(raw, type) {
+	if(!raw) { return null; }
+	raw = maybeDecodeUtf16(raw);
+	var candidates = (type === "text/uri-list" || type === "text/x-moz-url")
+		? raw.split(/\r?\n/)
+		: [raw];
+	for(var c = 0; c < candidates.length; c++) {
+		var line = candidates[c];
+		if(!line || line.charAt(0) === "#") { continue; }
+		// Find a data:text/vnd.tiddler URI either as the entire line (text/uri-list,
+		// text/x-moz-url) or embedded inside markup (text/html). Match on the still-
+		// URI-encoded form so JSON %22 doesn't truncate the capture; the stop-class
+		// excludes characters that cannot legally appear in a URI-encoded payload.
+		var encMatch = line.match(/^data:text\/vnd\.tiddler,(.*)$/i)
+			|| line.match(/data:text\/vnd\.tiddler,([^"'<>\s)]+)/i);
+		if(encMatch) {
+			try {
+				var parsed = JSON.parse(decodeURIComponent(encMatch[1]));
+				return Array.isArray(parsed) ? parsed : [parsed];
+			} catch(e) {}
+		}
+		// Or the line itself is raw JSON (legacy text/vnd.tiddler, an array of
+		// tiddler fields, or our self-identifying envelope).
+		if(line.charAt(0) === "{" || line.charAt(0) === "[") {
+			try {
+				var rawParsed = JSON.parse(line);
+				if(rawParsed && typeof rawParsed === "object" && !Array.isArray(rawParsed) &&
+					rawParsed.__type === "text/vnd.tiddler" && rawParsed.fields) {
+					return Array.isArray(rawParsed.fields) ? rawParsed.fields : [rawParsed.fields];
+				}
+				return Array.isArray(rawParsed) ? rawParsed : [rawParsed];
+			} catch(e) {}
+		}
+	}
+	return null;
+}
+
+function extractTiddlerFields(dataTransfer) {
+	if(!dataTransfer) { return null; }
+	var enumerated = [];
+	try {
+		for(var i = 0; i < (dataTransfer.types ? dataTransfer.types.length : 0); i++) {
+			enumerated.push(dataTransfer.types[i]);
+		}
+	} catch(e) {}
+	var allTypes = enumerated.slice();
+	PROBE_TYPES.forEach(function(t) {
+		if(allTypes.indexOf(t) === -1) { allTypes.push(t); }
+	});
+	for(var k = 0; k < allTypes.length; k++) {
+		var raw;
+		try {
+			raw = dataTransfer.getData(allTypes[k]);
+		} catch(e) {
+			continue;
+		}
+		if(!raw) { continue; }
+		var fields = tryDecodeTiddlerPayload(raw, allTypes[k]);
+		if(fields) { return fields; }
+	}
+	return null;
+}
+
+// Widget.dispatchEvent walks UP via parentWidget; dispatching on $tw.rootWidget
+// bubbles nowhere because there's no parent. The handler for tm-import-tiddlers
+// lives on the navigator widget, which is a descendant — so we walk down to
+// find a widget that registered the handler, then dispatch at that level.
+function findEventHandlerWidget(widget, eventType) {
+	if(!widget) { return null; }
+	if(widget.eventListeners && widget.eventListeners[eventType]) {
+		return widget;
+	}
+	if(widget.children) {
+		for(var i = 0; i < widget.children.length; i++) {
+			var found = findEventHandlerWidget(widget.children[i], eventType);
+			if(found) { return found; }
+		}
+	}
+	return null;
+}
+
+function makeDropHandler(getContentWindow) {
+	return function(event) {
+		var target = event.target;
+		if(target && (target.tagName === "TEXTAREA" || target.tagName === "INPUT" || target.isContentEditable)) {
+			return;
+		}
+		var dataTransfer = event.dataTransfer;
+		if(dataTransfer && dataTransfer.files && dataTransfer.files.length > 0) {
+			return;
+		}
+		var tiddlerFields = extractTiddlerFields(dataTransfer);
+		if(!tiddlerFields) { return; }
+		var contentWindow = getContentWindow();
+		var tw = contentWindow && contentWindow.$tw;
+		if(!tw || !tw.rootWidget) { return; }
+		var handlerWidget = findEventHandlerWidget(tw.rootWidget, "tm-import-tiddlers");
+		if(!handlerWidget) { return; }
+		event.preventDefault();
+		event.stopPropagation();
+		handlerWidget.dispatchEvent({
+			type: "tm-import-tiddlers",
+			param: JSON.stringify(tiddlerFields),
+			importTitle: "$:/Import",
+			paramObject: {importTitle: "$:/Import"}
+		});
+	};
+}
+
+function attachToDoc(doc, getContentWindow) {
+	doc.addEventListener("dragover", function(e) { e.preventDefault(); }, true);
+	doc.addEventListener("drop", makeDropHandler(getContentWindow), true);
+}
+
+exports.installImportInterceptor = function(doc, contentWindow, options) {
+	options = options || {};
+	if(!doc) { return; }
+	var get = function() { return contentWindow; };
+	var attachIframe = function() {
+		try { attachToDoc(doc, get); } catch(e) {}
+	};
+	if(doc.body) {
+		attachIframe();
+	} else {
+		var win = contentWindow || doc.defaultView;
+		if(win) {
+			win.addEventListener("DOMContentLoaded", attachIframe, {once: true});
+		}
+	}
+	if(options.parentDocument) {
+		try { attachToDoc(options.parentDocument, get); } catch(e) {}
+	}
+};

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -84,6 +84,7 @@ var $tw = {desktop: {
 	utils: {
 		devtools: require("../js/utils/devtools.js"),
 		dom: require("../js/utils/dom.js"),
+		dragdrop: require("../js/utils/dragdrop.js"),
 		file: require("../js/utils/file.js"),
 		links: require("../js/utils/links.js"),
 		menu: require("../js/utils/menu.js"),
@@ -142,37 +143,59 @@ var defaultCommand = "open",
 
 // Main boot process
 
-$tw.boot.suppressBoot = true;
-require("../tiddlywiki/boot/boot.js").TiddlyWiki($tw);
-$tw.boot.boot(function() {
-	// Process command line
-	var tokens = gui.App.argv.slice(0),
-		command, commandFn,
-		args;
-	while(tokens.length > 0) {
-		if(tokens[0].startsWith("--")) {
-			command = tokens.shift().slice(2);
-		} else {
-			command = defaultCommand;
+// If no wiki path was passed on the command line, eagerly open the wiki list
+// window now (with its lightweight loading splash) so the user sees a window
+// immediately. The heavy TiddlyWiki boot below paints the real content into
+// the already-open window via BackstageWindow.tryRender().
+var initialArgv = gui.App.argv.slice(0),
+	hasNonFlagArg = initialArgv.some(function(a) { return !a.startsWith("--"); });
+if(!hasNonFlagArg) {
+	$tw.desktop.windowList.openByUrl("backstage://WikiListWindow",{mustQuitOnClose: true});
+	commandFlags.haveOpenedWindow = true;
+}
+
+// Defer boot to the next tick so the splash window's renderer can paint
+// before the main process gets blocked by the synchronous TiddlyWiki boot.
+setTimeout(function() {
+	$tw.boot.suppressBoot = true;
+	require("../tiddlywiki/boot/boot.js").TiddlyWiki($tw);
+	$tw.boot.boot(function() {
+		// Process command line
+		var tokens = initialArgv,
+			command, commandFn,
+			args;
+		while(tokens.length > 0) {
+			if(tokens[0].startsWith("--")) {
+				command = tokens.shift().slice(2);
+			} else {
+				command = defaultCommand;
+			}
+			args = [];
+			while(tokens.length > 0 && !tokens[0].startsWith("--")) {
+				args.push(tokens.shift());
+			}
+			commandFn = commands[command];
+			if(!commandFn) {
+				console.error("Unknown command: --" + command);
+			} else {
+				commandFn(args);
+			}
 		}
-		args = [];
-		while(tokens.length > 0 && !tokens[0].startsWith("--")) {
-			args.push(tokens.shift());
+		// Register for file open events
+		// Commented out as an attempt to fix https://github.com/TiddlyWiki/TiddlyDesktop/issues/214
+		// gui.App.on("open",function(cmdline) {
+		// 	$tw.desktop.windowList.openByPathname(p);
+		// });
+		// Fallback: if nothing has been opened (e.g. only flag args), open the wiki list now
+		if(!commandFlags.haveOpenedWindow) {
+			$tw.desktop.windowList.openByUrl("backstage://WikiListWindow",{mustQuitOnClose: true});
 		}
-		commandFn = commands[command];
-		if(!commandFn) {
-			console.error("Unknown command: --" + command);
-		} else {
-			commandFn(args);
-		}
-	}
-	// Register for file open events
-	// Commented out as an attempt to fix https://github.com/TiddlyWiki/TiddlyDesktop/issues/214
-	// gui.App.on("open",function(cmdline) {
-	// 	$tw.desktop.windowList.openByPathname(p);
-	// });
-	// Open wiki list window if we haven't opened any other windows
-	if(!commandFlags.haveOpenedWindow) {
-		$tw.desktop.windowList.openByUrl("backstage://WikiListWindow",{mustQuitOnClose: true});		
-	}
-});
+		// Render any windows that were opened before boot completed
+		$tw.desktop.bootComplete = true;
+		$tw.desktop.windowList.windows.forEach(function(w) {
+			if(typeof w.tryRender === "function") {
+				w.tryRender();
+			}
+		});
+	});
+},0);

--- a/source/js/wiki-file-window.js
+++ b/source/js/wiki-file-window.js
@@ -92,6 +92,16 @@ WikiFileWindow.prototype.onloadiframe = function() {
 	$tw.desktop.utils.saving.enableSaving(this.iframe.contentDocument,areBackupsEnabledFn,loadFileTextFn);
 	// Trap links
 	$tw.desktop.utils.links.trapLinks(this.iframe.contentDocument);
+	// Intercept cross-browser drag-drop imports so tiddlers dragged from Firefox
+	// (which Chromium otherwise hands to TW as text/html) keep their fields
+	$tw.desktop.utils.dragdrop.installImportInterceptor(
+		this.iframe.contentDocument,
+		this.iframe.contentWindow,
+		{
+			parentDocument: this.window_nwjs.window.document,
+			parentWindow: this.window_nwjs.window
+		}
+	);
 	// Observe mutations of the title element of the iframe
 	this.titleObserver = new MutationObserver(this.extractIframeTitle.bind(this));
 	var iframeTitleNode = this.iframe.contentDocument.getElementsByTagName("title")[0];

--- a/source/js/wiki-folder-main.js
+++ b/source/js/wiki-folder-main.js
@@ -14,6 +14,7 @@ var $tw = {desktop: {
 	utils: {
 		devtools: require("../js/utils/devtools.js"),
 		dom: require("../js/utils/dom.js"),
+		dragdrop: require("../js/utils/dragdrop.js"),
 		menu: require("../js/utils/menu.js")
 	}
 }};
@@ -56,3 +57,12 @@ console.log("Running tiddlywiki " + $tw.boot.argv.join(" "));
 require("../tiddlywiki/boot/boot.js").TiddlyWiki($tw);
 
 $tw.wiki.addTiddler({title: "$:/status/IsReadOnly",text: "no"});
+
+// Intercept cross-browser drag-drop imports (same fix as wiki-file windows).
+// In the folder window the wiki document IS this window, so contentWindow
+// and the document are the window itself.
+$tw.desktop.utils.dragdrop.installImportInterceptor(
+	containerWindow.window.document,
+	containerWindow.window,
+	{parentWindow: containerWindow.window}
+);


### PR DESCRIPTION
# Faster wiki-list startup + cross-app drag-drop import on Linux

This PR bundles two independent improvements that touch the wiki-window plumbing. They're separable but were developed together — happy to split into two PRs if reviewers prefer.

## 1. Lazy-load the wiki list at startup

### Problem

On a cold launch (NW.js binaries not in the OS file cache) there is a noticeable delay before any window appears. The visible wiki-list window is opened from inside `boot.boot()`'s completion callback, so nothing renders until the entire backstage TW kernel has finished loading.

### Approach

Open the wiki-list `BackstageWindow` *before* calling `boot.boot()` and show a tiny CSS-only loading splash inside it. Defer the actual TW boot one tick via `setTimeout(0)` so the splash paints first; after boot completes, the now-open window's TW content is rendered into place.

### Files

- `source/html/backstage-tiddler-window.html` — adds a `td-loading-splash` element + scoped CSS (pure CSS spinner, no JS, no dependencies).
- `source/js/backstage-window.js` — splits the existing `onloaded` handler so the window shows immediately and a new `tryRender()` runs the TW-dependent setup (`renderWindow`, link/popup/menu/devtools wiring) only once both the window has loaded *and* `$tw` is fully booted. `tryRender` is idempotent. `onclose` is guarded against `$tw.wiki` being undefined in case the user closes the window mid-boot.
- `source/js/main.js` — pre-checks `gui.App.argv` for a wiki path; if there is none, opens the wiki-list eagerly and defers `boot.boot()` via `setTimeout(0)`. After boot completes, iterates `windowList.windows` and calls `tryRender()` on any pre-opened window.

### Compatibility

No public API changes. Wiki-list windows opened from the tray menu *after* boot has completed go through the same `tryRender()` path — both gating conditions are already satisfied, so they render immediately with the splash flashing only as long as the HTML load takes.

## 2. Cross-app drag-drop import for tiddlers from external browsers

### Problem

Dragging a tiddler (e.g. a plugin from tiddlywiki.com's plugin library) from a TiddlyWiki page running in an external browser into a wiki window in TiddlyDesktop fails on Linux: only the title is imported, all other tiddler fields including `plugin-type` are lost.

### Diagnosis

Cross-app drag-and-drop on Linux goes through OS protocols (XDND on X11, `wl_data_device` on Wayland). Chromium's outgoing sanitiser strips everything that isn't in a narrow standard allowlist. Empirical testing on Wayland and XWayland, with both Chrome and Firefox sources, showed that out of the seven MIME types TiddlyWiki's `makeDraggable` publishes (`text/vnd.tiddler`, `text/plain`, `text/x-moz-url`, `URL`, `Text`, plus the upstream variants tried later) **only `text/plain` and `text/html` survive the cross-app boundary**. `text/uri-list`, `application/json`, `text/json`, `application/vnd.tiddler+json` and the legacy `URL` alias are all dropped.

Once `text/html` was confirmed as the only rich channel that survives, two additional Chromium quirks had to be handled:

- **UTF-16LE encoding.** Chromium on Linux delivers `text/html` to JS as UTF-16LE bytes interpreted as Latin-1 — every "real" character is followed by `null`.
- **URI extraction must run on the still-URI-encoded form.** Decoding the whole HTML first turns `%22` (encoded `"`) into a literal `"`, which terminates the data URI regex prematurely and captures only `{`.

### Approach

A new TiddlyDesktop-side capture-phase drop interceptor that runs before TW's own `DropZoneWidget`. It:

1. Probes both `dataTransfer.types[]` and a hardcoded list of well-known MIME types via `getData()` (Chromium sometimes exposes data on types it doesn't enumerate).
2. If a value looks UTF-16LE-as-Latin-1, decodes via `TextDecoder("utf-16le")` (falling back to ASCII-safe stripping).
3. Matches `data:text/vnd.tiddler,…` on the URI-encoded form, then `decodeURIComponent`s only the captured payload.
4. Also accepts the bare-JSON form (`text/vnd.tiddler` when it does survive) and a self-identifying envelope `{"__type":"text/vnd.tiddler","fields":…}` for future-proofing.
5. Walks the widget tree from `$tw.rootWidget` down to find a widget that actually listens for `tm-import-tiddlers` (the navigator widget — `Widget.dispatchEvent` only walks *up*, so dispatching from the root bubbles nowhere). Dispatches `tm-import-tiddlers` on that widget so the standard `$:/Import` preview opens.

The interceptor is purely additive: if it doesn't find a tiddler payload, the event continues to TW's own dropzone untouched.

### Files

- `source/js/utils/dragdrop.js` (new) — the interceptor logic. ~150 lines, no dependencies, no console output. Exports `installImportInterceptor(doc, contentWindow, options)`.
- `source/js/main.js` — exposes the module as `$tw.desktop.utils.dragdrop`.
- `source/js/wiki-file-window.js` — calls `installImportInterceptor` after the iframe loads, passing both the iframe document and the outer window document so drops landing on either surface are caught.
- `source/js/wiki-folder-main.js` — same for the wiki-folder window, where the wiki document *is* the window itself.
- `test-drag.html` (new, optional) — standalone test page with several draggable tiles, each setting a different combination of MIME types. Useful for diagnosing future drag-drop regressions.

### Companion upstream patch

The receiver-side logic *should* eventually live in TiddlyWiki5 itself, inside the existing `importDataTypes[].text/html.toTiddlerFieldsArray`, so any TW receiver benefits — not just TiddlyDesktop. The matching source-side change adds a `setData("text/html", '<a href="data:text/vnd.tiddler,…">…</a>')` call to `makeDraggable`. I'll open that PR against Jermolene/TiddlyWiki5 separately. The interceptor in TiddlyDesktop remains useful indefinitely as a safety net for wikis built before the upstream change ships.

### Compatibility

The interceptor only acts on drops it can decode as a tiddler payload; anything else (text snippets, files, links from non-TW sources) falls through to TW's existing dropzone handling unchanged. Same-process drag-drop within a single wiki is unaffected — the rich `text/vnd.tiddler` payload is still preferred when it survives.

## Testing

Manual verification on Linux/Wayland + XWayland with both Chrome and Firefox as sources:

- [x] Cold launch shows a loading splash within a frame instead of a blank delay.
- [x] Tray-opened wiki list (warm boot) renders without splash flicker.
- [x] Wiki-list close while wiki windows are open keeps the process alive (unchanged behaviour, verified).
- [x] Drag a plugin tile from `tiddlywiki.com` (in Chrome) into a TiddlyDesktop wiki window → `$:/Import` opens with the full tiddler including `plugin-type: plugin` and shadow tiddlers.
- [x] Same from Firefox.
- [x] Drag a non-tiddler item (e.g. a hyperlink) → falls through to TW's default handling unchanged.
- [x] `test-drag.html` tile 6 (text/html with embedded `data:` URI) imports correctly; other tiles correctly fall through.

## Out of scope / follow-ups

- Upstream TiddlyWiki5 PR for the source-side `text/html` setData and the receiver-side decode in `importDataTypes`.
- Wiki-folder windows currently have no in-window UI (the folder window is a TW server only; the user views the wiki in their own browser). The interceptor is installed there for completeness but is effectively dormant.
- macOS / Windows behaviour has not been verified — the cross-app drag sanitiser is most aggressive on Linux, so the existing rich-MIME path should still work on the other platforms. No regression is expected because the interceptor is additive, but worth a smoke test before tagging a release.
