### PR TITLE
Fix plugin chooser backstage

### DIFF
--- a/plugins/tiddlydesktop/WikiListWindow.tid
+++ b/plugins/tiddlydesktop/WikiListWindow.tid
@@ -5,7 +5,10 @@ page-title: TiddlyDesktop -- Main
 
 <$transclude tiddler="$:/core/ui/PageTemplate/alerts" mode="inline"/>
 
-<$transclude tiddler="$:/TiddlyDesktop/PluginChooser" mode="inline"/>
+<!-- The chooser overlay for per-wiki installs. The backstage self-install target renders from the
+Settings > Plugins tab instead, so exclude it here — otherwise (on desktop, where the Settings and
+WikiList windows share the same $:/temp state) the overlay would show in BOTH windows. -->
+<$list filter="[[$:/temp/TiddlyDesktop/PluginChooser/target]!field:wiki-type[self]]" variable="_"><$transclude tiddler="$:/TiddlyDesktop/PluginChooser" mode="inline"/></$list>
 
 <$droplink>
 

--- a/plugins/tiddlydesktop/settings/Plugins.tid
+++ b/plugins/tiddlydesktop/settings/Plugins.tid
@@ -14,5 +14,8 @@ list** so the plugin activates.
 
 <!-- The chooser overlay is position:fixed, so transcluding it here makes it available whenever this
 Settings tab is shown — on both Desktop (separate Settings window) and Android (in-page Settings view),
-without touching the per-platform page templates. -->
+without touching the per-platform page templates. Gated to the self-target only, so it doesn't also
+appear here when a per-wiki chooser (rendered by WikiListWindow) is open. -->
+<$list filter="[[$:/temp/TiddlyDesktop/PluginChooser/target]field:wiki-type[self]]" variable="_">
 {{$:/TiddlyDesktop/PluginChooser}}
+</$list>


### PR DESCRIPTION
It currently renders the PluginChooser in Settings windows AND WikiList window.
This PR fixes that behavior.