### PR TITLE
Fix wiki folder attachments on Desktop. Fix Android Backup paths

### DIFF
--- a/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/MainActivity.kt
+++ b/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/MainActivity.kt
@@ -441,6 +441,14 @@ class MainActivity : ComponentActivity(), TDHost.Callbacks {
         backupFolderPathOrNull()?.let { openPath(it) } ?: toast(R.string.toast_no_backup_folder)
     }
 
+    // The WikiList reports $:/TiddlyDesktop/BackupPath here (on load and on change). Persisted
+    // app-wide so the :wiki-process saver and the PluginChooser lay backups out per the setting.
+    override fun setBackupPathTemplate(template: String) {
+        runCatching {
+            com.tiddlywiki.tiddlydesktop.node.Backups.backupPathTemplateFile(this).writeText(template.trim())
+        }
+    }
+
     private fun onPluginFolderPicked(uri: Uri) {
         val path = com.tiddlywiki.tiddlydesktop.host.SafPaths.toFilePath(uri)
         if (path == null) { toast(R.string.toast_pick_on_device_folder); return }
@@ -495,7 +503,8 @@ class MainActivity : ComponentActivity(), TDHost.Callbacks {
         if (treeUri.isBlank()) { toast(R.string.toast_no_folder_access_reveal); return@runOnUiThread }
         val wikiPath = WikiUrl.decode(url)?.path
         val fileName = wikiPath?.let { File(it).name } ?: "wiki.html"
-        val backupDir = File(treeUri, com.tiddlywiki.tiddlydesktop.node.Backups.backupDirName(fileName))
+        val subPath = com.tiddlywiki.tiddlydesktop.node.Backups.backupSubPath(this, fileName, wikiPath ?: "")
+        val backupDir = File(treeUri, subPath)
         if (backupDir.isDirectory) openPath(backupDir.absolutePath) else openPath(treeUri)
     }
 

--- a/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/host/TDHost.kt
+++ b/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/host/TDHost.kt
@@ -53,6 +53,9 @@ class TDHost(
         fun backupFolderPath(): String
         /** Open the global backup folder in the system file manager. */
         fun openBackupFolder()
+        /** Persist the backup-path template ($:/TiddlyDesktop/BackupPath) reported by the WikiList,
+         *  so the (separate-process) saver lays backups out per the user's setting. */
+        fun setBackupPathTemplate(template: String)
         /** Whether a shared payload is waiting to be imported into a wiki. */
         fun hasPendingShare(): Boolean
         /** Enriched metadata for the pending share (kind/title/description/image/embed/…) as JSON. */
@@ -133,6 +136,9 @@ class TDHost(
 
     @JavascriptInterface
     fun openBackupFolder() = callbacks.openBackupFolder()
+
+    @JavascriptInterface
+    fun setBackupPathTemplate(template: String) = callbacks.setBackupPathTemplate(template)
 
     @JavascriptInterface
     fun hasPendingShare(): Boolean = callbacks.hasPendingShare()

--- a/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/node/Backups.kt
+++ b/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/node/Backups.kt
@@ -20,11 +20,29 @@ object Backups {
 
     private const val TAG = "Backups"
 
+    // Default backup-path template — MUST match the desktop app's $:/TiddlyDesktop/BackupPath
+    // default (plugins/tiddlydesktop/config/BackupPath.tid) so both platforms lay backups out the
+    // same way. $filename$ expands to the wiki's full filename WITH extension, so this yields
+    // "<wiki>.html_backup/" — e.g. "mywiki.html_backup/", not "mywiki_backup/".
+    private const val DEFAULT_TEMPLATE = "./\$filename\$_backup/"
+
     /** App-private file holding the user's chosen global backup folder (a SAF tree URI). */
     fun backupFolderUriFile(context: Context): File = File(context.filesDir, "backup-folder.uri")
 
+    /**
+     * App-private file holding the backup-path template ($:/TiddlyDesktop/BackupPath), reported by
+     * the WikiList JS via TDHost.setBackupPathTemplate (see MainActivity). Absent => the desktop
+     * default above. Persisting it app-wide (like backup-folder.uri) means the :wiki process's
+     * saver reads the current value without threading it through every open-wiki intent.
+     */
+    fun backupPathTemplateFile(context: Context): File = File(context.filesDir, "backup-path-template.txt")
+
     private fun globalBackupDir(context: Context): String? =
         backupFolderUriFile(context).takeIf { it.exists() }?.readText()?.trim()?.ifBlank { null }
+
+    private fun template(context: Context): String =
+        backupPathTemplateFile(context).takeIf { it.exists() }?.readText()?.trim()?.ifBlank { null }
+            ?: DEFAULT_TEMPLATE
 
     /**
      * [backupDirUri] is the wiki's own containing folder (backups land next to it). If the user
@@ -44,7 +62,8 @@ object Backups {
     private fun writeFileTree(context: Context, wikiPath: String, oldBytes: ByteArray, folder: String, count: Int): Boolean =
         runCatching {
             val fileName = fileName(wikiPath); val base = baseName(fileName)
-            val dir = File(folder, backupDirName(fileName)).apply { mkdirs() }
+            val subPath = backupSubPath(context, fileName, wikiPath)
+            val dir = File(folder, subPath).apply { mkdirs() }
             File(dir, "$base-${ts()}.html").writeBytes(oldBytes)
             if (count > 0) {
                 dir.listFiles { f -> f.name.startsWith("$base-") }
@@ -58,21 +77,22 @@ object Backups {
         runCatching {
             val fileName = fileName(wikiPath); val base = baseName(fileName)
             val root = DocumentFile.fromTreeUri(context, Uri.parse(treeUri)) ?: return false
-            val dirName = backupDirName(fileName)
-            val dir = root.findFile(dirName) ?: root.createDirectory(dirName) ?: return false
+            val subPath = backupSubPath(context, fileName, wikiPath)
+            val dir = ensureSafDir(root, subPath) ?: return false
             val f = dir.createFile("text/html", "$base-${ts()}.html") ?: return false
             context.contentResolver.openOutputStream(f.uri, "wt")?.use { it.write(oldBytes) }
             if (count > 0) {
                 dir.listFiles().filter { it.name?.startsWith("$base-") == true }
                     .sortedByDescending { it.lastModified() }.drop(count).forEach { it.delete() }
             }
-            Log.i(TAG, "Backed up ${oldBytes.size} bytes to SAF $dirName/")
+            Log.i(TAG, "Backed up ${oldBytes.size} bytes to SAF $subPath/")
             true
         }.getOrElse { Log.w(TAG, "SAF backup failed: ${it.message}"); false }
 
     private fun writeAppPrivate(context: Context, wikiPath: String, oldBytes: ByteArray, count: Int) {
         val fileName = fileName(wikiPath); val base = baseName(fileName)
-        val dir = File(File(context.filesDir, "backups"), md5(wikiPath)).apply { mkdirs() }
+        val subPath = backupSubPath(context, fileName, wikiPath)
+        val dir = File(File(File(context.filesDir, "backups"), md5(wikiPath)), subPath).apply { mkdirs() }
         File(dir, "$base-${ts()}.html").writeBytes(oldBytes)
         if (count > 0) {
             dir.listFiles { f -> f.name.startsWith("$base-") }
@@ -87,8 +107,36 @@ object Backups {
 
     private fun baseName(fileName: String): String = fileName.substringBeforeLast('.').ifBlank { "wiki" }
 
-    /** Backup folder name for a wiki file, e.g. "mywiki.html" -> "mywiki_backup". */
-    fun backupDirName(fileName: String): String = "${baseName(fileName)}_backup"
+    /**
+     * The backup directory for a wiki, RELATIVE to the target base folder, derived from the
+     * template ($:/TiddlyDesktop/BackupPath). Mirrors the desktop app (utils/saving.js
+     * backupPathByPath): $filename$ -> the wiki's full filename WITH extension (e.g. "wiki.html"),
+     * $filepath$ -> its full path. Supports arbitrary/nested templates like
+     * "./test/$filename$123_backup/". Returns a forward-slash sub-path with no leading "./" or "/"
+     * and no trailing "/". Public so "reveal backups" (MainActivity) resolves the identical folder.
+     */
+    fun backupSubPath(context: Context, fileName: String, wikiPath: String): String {
+        var s = template(context)
+            .replace("\$filename\$", fileName, ignoreCase = true)
+            .replace("\$filepath\$", wikiPath, ignoreCase = true)
+            .replace('\\', '/')
+            .trim()
+        // The template is resolved relative to the target base folder, so drop a leading "./" or
+        // "/" and any trailing slash. Blank (a template of just "./") falls back to the default.
+        if (s.startsWith("./")) s = s.substring(2)
+        s = s.trimStart('/').trimEnd('/')
+        return s.ifBlank { "${fileName}_backup" }
+    }
+
+    /** Create (or find) a possibly-nested sub-directory under a SAF tree, segment by segment. */
+    private fun ensureSafDir(root: DocumentFile, subPath: String): DocumentFile? {
+        var dir = root
+        for (seg in subPath.split('/')) {
+            if (seg.isBlank()) continue
+            dir = dir.findFile(seg)?.takeIf { it.isDirectory } ?: dir.createDirectory(seg) ?: return null
+        }
+        return dir
+    }
 
     private fun ts(): String = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
 

--- a/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/node/WikiOps.kt
+++ b/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/node/WikiOps.kt
@@ -67,6 +67,17 @@ object WikiOps {
                 out.copyRecursively(File(destFolder).apply { mkdirs() }, overwrite = true); true
             }.getOrElse { Log.e(TAG, "fileToFolder copy failed: ${it.message}"); false }
         }
+        // Carry an external-attachments folder across the conversion (mirrors desktop convertWiki):
+        // both wiki forms keep attachments in a sibling "attachments/" dir referenced relatively as
+        // "./attachments/<name>", so the conversion just copies that directory — here from beside
+        // the source .html into the new folder. On-device paths only (content:// has no fs parent).
+        if (ok && !sourcePath.startsWith("content://")) {
+            runCatching {
+                val srcAttach = File(sourcePath).parentFile?.let { File(it, "attachments") }
+                if (srcAttach != null && srcAttach.isDirectory)
+                    srcAttach.copyRecursively(File(File(destFolder), "attachments"), overwrite = true)
+            }.onFailure { Log.w(TAG, "fileToFolder attachments copy: ${it.message}") }
+        }
         work.deleteRecursively()
         return ok
     }
@@ -82,6 +93,17 @@ object WikiOps {
         ))
         val result = File(out, "wiki.html")
         val ok = code == 0 && result.exists() && writeBytes(context, destFileUri, result.readBytes())
+        // Carry the external-attachments folder across (mirrors desktop convertWiki): copy the
+        // folder wiki's attachments/ next to the produced .html so its relative "./attachments/<name>"
+        // references keep resolving. On-device destinations only (content:// has no fs parent).
+        if (ok && !destFileUri.startsWith("content://")) {
+            runCatching {
+                val srcAttach = File(local, "attachments")
+                val dstParent = File(destFileUri).parentFile
+                if (srcAttach.isDirectory && dstParent != null)
+                    srcAttach.copyRecursively(File(dstParent, "attachments"), overwrite = true)
+            }.onFailure { Log.w(TAG, "folderToFile attachments copy: ${it.message}") }
+        }
         work.deleteRecursively()
         return ok
     }

--- a/TiddlyDesktopAndroid/packaging/wikilist-android/tiddlers/android-desktop.js
+++ b/TiddlyDesktopAndroid/packaging/wikilist-android/tiddlers/android-desktop.js
@@ -338,6 +338,22 @@ exports.startup = function () {
 		try { var bp = host.backupFolderPath(); if (bp) { window.__tdSetBackupPath(bp); } } catch (e) {}
 	}
 
+	// Report the backup-path template ($:/TiddlyDesktop/BackupPath) to native so the saver (which
+	// runs in the separate :wiki process) and the PluginChooser lay backups out per the user's
+	// setting — the same template the desktop app reads at save time. Reported on load and whenever
+	// the setting changes; native persists it app-wide (see MainActivity.setBackupPathTemplate).
+	window.__tdReportBackupTemplate = function () {
+		if (host && host.setBackupPathTemplate) {
+			try {
+				host.setBackupPathTemplate($tw.wiki.getTiddlerText("$:/TiddlyDesktop/BackupPath", "./$filename$_backup/"));
+			} catch (e) {}
+		}
+	};
+	window.__tdReportBackupTemplate();
+	$tw.wiki.addEventListener("change", function (changes) {
+		if (changes["$:/TiddlyDesktop/BackupPath"]) { window.__tdReportBackupTemplate(); }
+	});
+
 	window.__tdSetConfigPath = function (path) {
 		$tw.wiki.addTiddler(new $tw.Tiddler({ title: "$:/TiddlyDesktop/Config/config-folder-path", text: path }));
 	};

--- a/plugins/tiddlydesktop/styles/buttons.tid
+++ b/plugins/tiddlydesktop/styles/buttons.tid
@@ -35,3 +35,12 @@ a.td-button {
 a.td-button:hover {
 	text-decoration: none;
 }
+
+/* TiddlyWiki's vanilla base sizes toolbar icons with `button svg.tc-image-button { height/width:
+   1em }` — but that only matches icons inside a <button>. The Support control is an <a>, so its
+   heart icon would otherwise render at its full intrinsic size (22pt). Clamp icons in any td-button
+   (button or link) to 1em so they all match. */
+.td-button svg.tc-image-button {
+	height: 1em;
+	width: 1em;
+}

--- a/source/js/wiki-folder-main.js
+++ b/source/js/wiki-folder-main.js
@@ -86,6 +86,69 @@ if (queryObject.host && queryObject.port) {
 	}
 }
 
+// External attachments for folder wikis (part 1 of 2 — see the import hook after boot). A folder
+// wiki renders from the html/ app page, so document.baseURI is that app directory: a wiki-relative
+// _canonical_uri (e.g. "pics/foo.png" or "../media/foo.png", relative to the WIKI FOLDER) would
+// resolve against html/ and 404. We must NOT rewrite the STORED value — it stays relative so the
+// tiddler still works when the folder is served over the LAN. Instead we wrap setAttribute on THIS
+// window so that, at the instant TiddlyWiki sets a media element's src (or an <a> href) to a
+// wiki-relative value, it is rewritten to resolve against file://<wikiFolder>/ . Doing this
+// synchronously inside setAttribute — installed BEFORE boot renders — means the browser never sees
+// the wrong URL, so there is no transient failed request. It covers every path uniformly: the
+// image/audio/video widgets AND raw HTML <img>/<audio> in wikitext all set src via setAttribute,
+// with no core-widget overrides. Absolute file:// URIs (the default for files outside the wiki, and
+// what collab records in "use absolute" mode) carry a scheme, so they're left untouched and load
+// directly. This also fixes collab-received attachments that are stored relative.
+var wikiFolderPath = $tw.boot.wikiPath || queryObject.pathname;
+
+// The wiki folder as a trailing-slashed file:// base (for resolving wiki-relative URIs).
+function wikiFolderFileBase() {
+	if (!wikiFolderPath) {
+		return null;
+	}
+	var p = String(wikiFolderPath).replace(/\\/g, "/");
+	if (p.charAt(0) !== "/") {
+		p = "/" + p;
+	} // C:/… -> /C:/… so it becomes file:///C:/…
+	if (p.slice(-1) !== "/") {
+		p += "/";
+	}
+	return "file://" + encodeURI(p);
+}
+
+(function () {
+	var base = wikiFolderFileBase();
+	var win = containerWindow.window;
+	if (!base || !win || !win.Element || !win.Element.prototype || win.__tdAttachmentRebaseInstalled) {
+		return;
+	}
+	win.__tdAttachmentRebaseInstalled = true;
+	// Media elements whose src TiddlyWiki fills from a _canonical_uri; <iframe> is excluded (media
+	// embeds are handled elsewhere and use absolute http URLs).
+	var SRC_TAGS = { IMG: 1, EMBED: 1, AUDIO: 1, VIDEO: 1, SOURCE: 1, TRACK: 1 };
+	// Wiki-relative = no scheme, not protocol-relative, not a bare fragment/query. "./x", "../x",
+	// "attachments/x", "x.png" qualify; "http(s):", "data:", "file:", "blob:", "#t", "?q" do not.
+	function isRelative(v) {
+		return typeof v === "string" && !!v && !/^(?:[a-z][a-z0-9+.\-]*:|\/\/|#|\?)/i.test(v);
+	}
+	var proto = win.Element.prototype;
+	var nativeSetAttribute = proto.setAttribute;
+	proto.setAttribute = function (name, value) {
+		// Fast path: only src/href are candidates, so most setAttribute calls skip straight through.
+		if (name === "src" || name === "href") {
+			if (
+				this && this.tagName && isRelative(value) &&
+				(name === "src" ? SRC_TAGS[this.tagName] : this.tagName === "A")
+			) {
+				try {
+					value = new win.URL(value, base).href;
+				} catch (e) {}
+			}
+		}
+		return nativeSetAttribute.call(this, name, value);
+	};
+})();
+
 console.log("Running tiddlywiki " + $tw.boot.argv.join(" "));
 
 // Main part of boot process — timed so a slow folder-wiki load can be localised in the
@@ -236,47 +299,93 @@ try {
 	schedule();
 })();
 
-// External attachments for folder wikis. The stock external-attachments plugin only
-// activates when the wiki document is itself a file:// URL (single-file wikis) and
-// computes the path relative to document.location — neither holds for a folder wiki,
-// which renders from a fixed app page (html/wiki-folder-window.html), not the wiki file.
-// Here we have Node and the app's --allow-file-access flags, so we can reference the
-// dropped file in place via an ABSOLUTE file:// URI that the renderer loads directly —
-// no HTTP server needed. Honours the same Enable switch. We register this hook FIRST so
-// it authoritatively handles binary imports before the stock plugin (whose relative-path
-// logic would otherwise produce a broken _canonical_uri here).
+// External attachments for folder wikis (part 2 of 2 — resolution is set up before boot, above).
+//
+// (1) IMPORT. On desktop we do NOT copy the dropped file into the wiki; we reference it IN PLACE,
+// exactly like the stock external-attachments plugin — the file stays where the user has it. The
+// stock plugin can't do this for a folder wiki, though: it only fires on a file:// wiki document
+// and computes the path relative to document.location, which here is the html/ app page, not the
+// wiki. We have Node, so we compute the _canonical_uri ourselves against the WIKI FOLDER, honouring
+// the same relative/absolute settings the plugin exposes (descendents default to relative, non-
+// descendents to absolute — a relative path that climbs out of the wiki tree is fragile). Relative
+// results resolve at render time via the setAttribute rebasing installed before boot; absolute
+// file:// results are used as-is.
+//
+// $tw.hooks.invokeHook pipes each hook's RETURN VALUE into the next hook and returns the LAST
+// hook's value; wiki.readFile then runs a normal (inline) import unless that final value is exactly
+// true. So a single "handle it and return true" hook is not enough: the stock hook, registered
+// after ours, would be handed our boolean, return false, and the importer would ALSO import the
+// file inline — and being async that inline import wins, embedding the bytes. We therefore split
+// into two hooks around a shared flag: `claim` runs FIRST (so it receives the real info object) and
+// does the work; `settle` runs LAST and forces the final return value to true whenever we claimed,
+// so no inline import follows. When we don't claim, `settle` passes the piped value through
+// untouched, leaving other importers unaffected.
 (function () {
 	if (!$tw.hooks || !$tw.hooks.addHook) {
 		return;
 	}
-	function folderExternalAttachmentHook(info) {
+	// Forward-slash relative path FROM the wiki folder TO an absolute file path (both forward-slash).
+	function relativeToWikiFolder(baseDir, absPath) {
+		var a = baseDir.split("/"),
+			b = absPath.split("/"),
+			i = 0;
+		while (i < a.length && i < b.length && a[i] === b[i]) {
+			i++;
+		}
+		var up = [];
+		for (var j = i; j < a.length; j++) {
+			up.push("..");
+		}
+		return up.concat(b.slice(i)).join("/") || ".";
+	}
+	// The _canonical_uri for a dropped file, referenced in place and resolved against the wiki
+	// folder. Mirrors the stock plugin's makePathRelative, but rooted at the wiki folder (not the
+	// app page) and reading the plugin's own UseAbsolute settings.
+	function canonicalUriForDroppedFile(filePath) {
+		var abs = String(filePath).replace(/\\/g, "/");
+		if (abs.charAt(0) !== "/") {
+			abs = "/" + abs;
+		} // C:/… -> /C:/…
+		var baseDir = String(wikiFolderPath).replace(/\\/g, "/").replace(/\/+$/, "");
+		if (baseDir.charAt(0) !== "/") {
+			baseDir = "/" + baseDir;
+		}
+		var isDescendent = abs === baseDir || abs.indexOf(baseDir + "/") === 0;
+		var useAbsolute =
+			$tw.wiki.getTiddlerText(
+				isDescendent
+					? "$:/config/ExternalAttachments/UseAbsoluteForDescendents"
+					: "$:/config/ExternalAttachments/UseAbsoluteForNonDescendents",
+				isDescendent ? "no" : "yes",
+			) === "yes";
+		// encodeURI matches how TiddlyWiki's external-attachments records URIs (spaces -> %20 etc.).
+		return useAbsolute
+			? "file://" + encodeURI(abs)
+			: encodeURI(relativeToWikiFolder(baseDir, abs));
+	}
+	var claimed = false;
+	function claim(info) {
+		claimed = false;
 		try {
 			if (
 				info &&
 				info.isBinary &&
 				info.file &&
 				info.file.path &&
+				wikiFolderPath &&
 				$tw.wiki.getTiddlerText(
 					"$:/config/ExternalAttachments/Enable",
 					"",
 				) === "yes"
 			) {
-				var p = String(info.file.path).replace(
-					/\\/g,
-					"/",
-				);
-				if (p.charAt(0) !== "/") {
-					p = "/" + p;
-				} // -> file:///C:/... on Windows
 				info.callback([
 					{
 						title: info.file.name,
 						type: info.type,
-						_canonical_uri:
-							"file://" +
-							encodeURI(p),
+						_canonical_uri: canonicalUriForDroppedFile(info.file.path),
 					},
 				]);
+				claimed = true;
 				return true;
 			}
 		} catch (e) {
@@ -287,15 +396,20 @@ try {
 		}
 		return false;
 	}
+	function settle(value) {
+		if (claimed) {
+			claimed = false;
+			return true;
+		}
+		return value;
+	}
 	var arr = $tw.hooks.names && $tw.hooks.names["th-importing-file"];
 	if (arr && typeof arr.unshift === "function") {
-		arr.unshift(folderExternalAttachmentHook); // run before the stock plugin's hook
+		arr.unshift(claim); // runs first: receives the real info object
 	} else {
-		$tw.hooks.addHook(
-			"th-importing-file",
-			folderExternalAttachmentHook,
-		);
+		$tw.hooks.addHook("th-importing-file", claim);
 	}
+	$tw.hooks.addHook("th-importing-file", settle); // runs last: controls the final return value
 })();
 
 // Fullscreen: F11 and the fullscreen page-control button toggle the native window.

--- a/source/js/window-list.js
+++ b/source/js/window-list.js
@@ -613,6 +613,23 @@ WindowList.prototype.convertWiki = function(sourceUrl, destPath, callback) {
 				// instead, leaving only genuinely custom plugins in the folder.
 				try { self.pruneResolvablePluginsFromFolder(destPath); } catch(_e) {}
 			}
+			// Carry an external-attachments folder across the conversion. Both wiki forms keep
+			// attachments in a sibling "attachments/" directory — folder wikis inside the folder,
+			// single-file wikis next to the .html — and reference them relatively as
+			// "./attachments/<name>", so the conversion only has to copy that directory to the
+			// destination; the relative _canonical_uri values keep resolving unchanged. No-op
+			// when the source has no attachments/ folder.
+			try {
+				var srcAttach = isFolder
+					? path.resolve(sourcePath,"attachments")                // folder -> file: from inside the folder
+					: path.resolve(path.dirname(sourcePath),"attachments"); // file -> folder: from beside the .html
+				var dstAttach = isFolder
+					? path.resolve(path.dirname(destPath),"attachments")    // -> beside the produced .html
+					: path.resolve(destPath,"attachments");                 // -> inside the produced folder
+				if(fs.existsSync(srcAttach) && fs.statSync(srcAttach).isDirectory()) {
+					$tw.utils.copyDirectory(srcAttach,dstAttach);
+				}
+			} catch(_e) { console.error("[TiddlyDesktop] convertWiki: attachments copy failed:",_e); }
 			console.log("[TiddlyDesktop] convertWiki: opening converted wiki",newUrl);
 			self.openByUrl(newUrl);
 			callback(null);


### PR DESCRIPTION
Android backup paths now respect the user setting

Wiki folders on desktop now work correctly with relative and absolute paths + external attachments plugin