### PR TITLE
Spellcheck settings

### DIFF
--- a/plugins/tiddlydesktop/config/EnableGoogleSpellcheck.tid
+++ b/plugins/tiddlydesktop/config/EnableGoogleSpellcheck.tid
@@ -1,0 +1,3 @@
+title: $:/config/TiddlyDesktop/EnableGoogleSpellcheck
+
+no

--- a/plugins/tiddlydesktop/config/EnableSpellcheck.tid
+++ b/plugins/tiddlydesktop/config/EnableSpellcheck.tid
@@ -1,0 +1,3 @@
+title: $:/config/TiddlyDesktop/EnableSpellcheck
+
+yes

--- a/plugins/tiddlydesktop/settings/Spellcheck.tid
+++ b/plugins/tiddlydesktop/settings/Spellcheck.tid
@@ -1,0 +1,13 @@
+title: $:/TiddlyDesktop/Settings/Spellcheck
+caption: Spellcheck
+tags: $:/TiddlyDesktop/Settings
+
+~TiddlyDesktop can check the spelling of text you type in editors, underlining likely misspellings. This uses Chromium's built-in ''local'' dictionary — nothing you type is sent anywhere.
+
+<$checkbox tiddler="$:/config/TiddlyDesktop/EnableSpellcheck" field="text" checked="yes" unchecked="no" default="yes"> Enable local spellcheck </$checkbox>
+
+Takes effect on a wiki's next (re)load — no need to restart ~TiddlyDesktop.
+
+! Privacy
+
+Chromium also offers an ''enhanced'' spellcheck that sends everything you type to Google's servers for suggestions. Because the underlying engine (NW.js) enables that remote service by default, ~TiddlyDesktop ''always'' turns it off at startup, regardless of the setting above — only the local dictionary is ever used.

--- a/plugins/tiddlydesktop/settings/Spellcheck.tid
+++ b/plugins/tiddlydesktop/settings/Spellcheck.tid
@@ -8,6 +8,10 @@ tags: $:/TiddlyDesktop/Settings
 
 Takes effect on a wiki's next (re)load — no need to restart ~TiddlyDesktop.
 
-! Privacy
+! Privacy: Google spellcheck service
 
-Chromium also offers an ''enhanced'' spellcheck that sends everything you type to Google's servers for suggestions. Because the underlying engine (NW.js) enables that remote service by default, ~TiddlyDesktop ''always'' turns it off at startup, regardless of the setting above — only the local dictionary is ever used.
+Chromium also offers an ''enhanced'' spellcheck that sends everything you type in an editor to Google's servers for suggestions. Because the underlying engine (NW.js) would enable this by default, ~TiddlyDesktop keeps it ''off'' unless you opt in here.
+
+<$checkbox tiddler="$:/config/TiddlyDesktop/EnableGoogleSpellcheck" field="text" checked="yes" unchecked="no" default="no"> Use Google's remote spellcheck service (sends your text to Google) </$checkbox>
+
+<div class="tc-message-box">This takes effect only after you ''restart ~TiddlyDesktop'', and only while local spellcheck (above) is enabled.</div>

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -12,6 +12,7 @@ var WindowList = require("../js/window-list.js").WindowList;
 var protocol = require("../js/utils/protocol.js");
 var deeplink = require("../js/utils/deeplink.js");
 var startupGuard = require("../js/utils/startup-guard.js");
+var spellcheck = require("../js/utils/spellcheck.js");
 
 // On a Chromium (NW.js) upgrade, clear Chromium's disposable GPU/shader caches and any stale
 // Singleton lock BEFORE booting — a stale cache from the old Chromium is a classic blank/no-window
@@ -280,6 +281,17 @@ setTimeout(function() {
 			if(typeof w.tryRender === "function") {
 				w.tryRender();
 			}
+		});
+		// Local-spellcheck toggle: apply to the backstage window now, and re-apply to it plus every
+		// open single-file wiki whenever the setting changes — no app restart. (Folder wikis run in
+		// their own process and pick up the change on their next open/reload.)
+		spellcheck.applyToDocument(document, spellcheck.isEnabled($tw));
+		$tw.wiki.addEventListener("change", function(changes) {
+			if(!changes[spellcheck.CONFIG_TITLE]) { return; }
+			spellcheck.applyToDocument(document, spellcheck.isEnabled($tw));
+			$tw.desktop.windowList.windows.forEach(function(w) {
+				try { if(typeof w.applySpellcheck === "function") { w.applySpellcheck(); } } catch(e) {}
+			});
 		});
 		// If launched cold by a tiddlydesktop:// deep link, act on it now that there's a window.
 		if(_coldStartDeepLink) { try { deeplink.handleUrl(_coldStartDeepLink); } catch(e) {} }

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -286,12 +286,26 @@ setTimeout(function() {
 		// open single-file wiki whenever the setting changes — no app restart. (Folder wikis run in
 		// their own process and pick up the change on their next open/reload.)
 		spellcheck.applyToDocument(document, spellcheck.isEnabled($tw));
+		// Google remote-spellcheck opt-in: mirror the config tiddler into the on-disk marker node-main
+		// reads before Chromium boots. It only takes effect on the NEXT launch (the preference is read
+		// at profile load), so there is nothing to apply to live windows here.
+		function syncGoogleSpellcheckMarker() {
+			try {
+				spellcheck.setGoogleServiceAllowed(gui.App.dataPath,
+					$tw.wiki.getTiddlerText(spellcheck.GOOGLE_CONFIG_TITLE,"no") === "yes");
+			} catch(e) {}
+		}
+		syncGoogleSpellcheckMarker();
 		$tw.wiki.addEventListener("change", function(changes) {
-			if(!changes[spellcheck.CONFIG_TITLE]) { return; }
-			spellcheck.applyToDocument(document, spellcheck.isEnabled($tw));
-			$tw.desktop.windowList.windows.forEach(function(w) {
-				try { if(typeof w.applySpellcheck === "function") { w.applySpellcheck(); } } catch(e) {}
-			});
+			if(changes[spellcheck.CONFIG_TITLE]) {
+				spellcheck.applyToDocument(document, spellcheck.isEnabled($tw));
+				$tw.desktop.windowList.windows.forEach(function(w) {
+					try { if(typeof w.applySpellcheck === "function") { w.applySpellcheck(); } } catch(e) {}
+				});
+			}
+			if(changes[spellcheck.GOOGLE_CONFIG_TITLE]) {
+				syncGoogleSpellcheckMarker();
+			}
 		});
 		// If launched cold by a tiddlydesktop:// deep link, act on it now that there's a window.
 		if(_coldStartDeepLink) { try { deeplink.handleUrl(_coldStartDeepLink); } catch(e) {} }

--- a/source/js/node-main.js
+++ b/source/js/node-main.js
@@ -54,3 +54,12 @@ try {
 } catch(e) {
 	try { console.error("[TiddlyDesktop] node-main guard failed:", e); } catch(_e) {}
 }
+
+// Force Chromium's remote (Google) spelling service off before the profile is opened. --enable-spell-checking
+// (source/package.json) otherwise makes NW.js send typed text to Google by default; we keep only the local
+// Hunspell spellcheck. Isolated from the guard above so a failure here can't affect startup recovery.
+try {
+	require("./utils/spellcheck.js").disableSpellingService(resolveProfileDir());
+} catch(e) {
+	try { console.error("[TiddlyDesktop] disable-spelling-service failed:", e); } catch(_e) {}
+}

--- a/source/js/node-main.js
+++ b/source/js/node-main.js
@@ -55,11 +55,13 @@ try {
 	try { console.error("[TiddlyDesktop] node-main guard failed:", e); } catch(_e) {}
 }
 
-// Force Chromium's remote (Google) spelling service off before the profile is opened. --enable-spell-checking
-// (source/package.json) otherwise makes NW.js send typed text to Google by default; we keep only the local
-// Hunspell spellcheck. Isolated from the guard above so a failure here can't affect startup recovery.
+// Sync Chromium's remote (Google) spelling-service preference before the profile is opened.
+// --enable-spell-checking (source/package.json) otherwise makes NW.js send typed text to Google by
+// default; we keep it OFF unless the user opted in (an on-disk marker written by the settings UI, since
+// this runs before TiddlyWiki boots). Isolated from the guard above so a failure here can't affect
+// startup recovery.
 try {
-	require("./utils/spellcheck.js").disableSpellingService(resolveProfileDir());
+	require("./utils/spellcheck.js").syncSpellingServicePref(resolveProfileDir());
 } catch(e) {
-	try { console.error("[TiddlyDesktop] disable-spelling-service failed:", e); } catch(_e) {}
+	try { console.error("[TiddlyDesktop] sync-spelling-service failed:", e); } catch(_e) {}
 }

--- a/source/js/utils/spellcheck.js
+++ b/source/js/utils/spellcheck.js
@@ -3,19 +3,23 @@ Spellcheck helpers for TiddlyDesktop.
 
 Two deliberately separate concerns:
 
-1. disableSpellingService(profileDir) — runs from node-main BEFORE Chromium opens the profile.
-   NW.js turns Google's REMOTE "spelling service" (the kSpellCheckUseSpellingService preference) on by
-   default whenever --enable-spell-checking is set (see nwjs/nw.js#5129), which ships everything the
-   user types into an editor to Google for suggestions. We force that preference off in the Chromium
-   "Preferences" file so only the LOCAL Hunspell dictionary is ever used and no typed text leaves the
-   machine. Fail-safe and idempotent; re-applied every launch because Chromium rewrites Preferences on
-   shutdown. This covers every window (all share the one Chromium profile), including folder wikis.
+1. The Chromium remote (Google) spelling service. NW.js turns Google's REMOTE "spelling service" (the
+   kSpellCheckUseSpellingService preference) on by default whenever --enable-spell-checking is set (see
+   nwjs/nw.js#5129), which ships everything the user types into an editor to Google for suggestions. It
+   is OFF by default in TiddlyDesktop and opt-in via $:/config/TiddlyDesktop/EnableGoogleSpellcheck.
+   syncSpellingServicePref(profileDir) writes the matching preference into the Chromium "Preferences"
+   file from node-main, BEFORE Chromium opens the profile — the only safe time to touch Preferences.
+   Because node-main runs before TiddlyWiki boots it cannot read that config tiddler, so the settings UI
+   mirrors the tiddler into an on-disk marker file (setGoogleServiceAllowed) that node-main can read
+   (isGoogleServiceAllowed). Changing the opt-in therefore takes effect on the NEXT launch. Fail-safe
+   and idempotent. This covers every window (all share the one Chromium profile), including folder wikis.
 
 2. isEnabled($tw) / applyToDocument(doc, enabled) — the user-facing on/off toggle for LOCAL spellcheck
    ($:/config/TiddlyDesktop/EnableSpellcheck, default "yes"). Chromium keeps --enable-spell-checking on
    so the engine is always available; we gate the visible red squiggles per document via the inherited
    `spellcheck` attribute on <html>. Editors that don't set their own attribute inherit it, so the
-   toggle takes effect on the next wiki (re)load with no app restart.
+   toggle takes effect on the next wiki (re)load with no app restart. (With local spellcheck off no text
+   is checked at all, so the Google service — even if opted in — never runs.)
 */
 
 "use strict";
@@ -23,14 +27,47 @@ Two deliberately separate concerns:
 var CONFIG_TITLE = "$:/config/TiddlyDesktop/EnableSpellcheck";
 exports.CONFIG_TITLE = CONFIG_TITLE;
 
-// Force Chromium's remote (Google) spelling service off in the profile's Preferences file. profileDir
-// is the active profile dir (e.g. .../TiddlyDesktop/Default). Only safe to call while Chromium is not
-// running against that profile — i.e. from node-main, before the first window opens.
-exports.disableSpellingService = function(profileDir) {
+var GOOGLE_CONFIG_TITLE = "$:/config/TiddlyDesktop/EnableGoogleSpellcheck";
+exports.GOOGLE_CONFIG_TITLE = GOOGLE_CONFIG_TITLE;
+
+// Path of the opt-in marker file. Its presence means the user has opted into Google's remote spelling
+// service; absence (the default) means keep it off. Lives in the profile dir so node-main can find it
+// from the same resolveProfileDir() it already uses.
+function markerPath(profileDir) {
+	return require("path").join(profileDir, "td-allow-google-spellcheck");
+}
+
+// True if the user has opted into the Google remote spelling service. Read by node-main before boot.
+exports.isGoogleServiceAllowed = function(profileDir) {
+	try { return !!profileDir && require("fs").existsSync(markerPath(profileDir)); } catch(e) { return false; }
+};
+
+// Create/remove the opt-in marker to mirror the config tiddler. Called from main.js when the setting
+// changes. Takes effect on the NEXT launch (Chromium reads the preference at profile load).
+exports.setGoogleServiceAllowed = function(profileDir, allowed) {
+	var fs = require("fs");
+	try {
+		if(!profileDir) { return; }
+		var p = markerPath(profileDir);
+		if(allowed) {
+			try { fs.mkdirSync(profileDir, {recursive: true}); } catch(e) {}
+			try { fs.writeFileSync(p, ""); } catch(e) {}
+		} else {
+			try { fs.unlinkSync(p); } catch(e) {}
+		}
+	} catch(e) {}
+};
+
+// Set Chromium's remote (Google) spelling-service preference in the profile's Preferences file to match
+// the opt-in marker: OFF by default (nothing typed leaves the machine), ON only if the user opted in.
+// profileDir is the active profile dir (e.g. .../TiddlyDesktop/Default). Only safe to call while Chromium
+// is NOT running against that profile — i.e. from node-main, before the first window opens.
+exports.syncSpellingServicePref = function(profileDir) {
 	var fs = require("fs"), path = require("path");
 	try {
 		if(!profileDir) { return; }
-		var prefsPath = path.join(profileDir, "Preferences"),
+		var allowed = exports.isGoogleServiceAllowed(profileDir),
+			prefsPath = path.join(profileDir, "Preferences"),
 			prefs = {},
 			existed = false;
 		try {
@@ -38,14 +75,14 @@ exports.disableSpellingService = function(profileDir) {
 			existed = true;
 		} catch(e) { prefs = {}; }
 		prefs.spellcheck = prefs.spellcheck || {};
-		// Already off in an existing file → nothing to do. (A fresh profile has no file yet, so we
-		// still pre-seed it below so the very first launch never enables the Google service.)
-		if(existed && prefs.spellcheck.use_spelling_service === false) { return; }
-		prefs.spellcheck.use_spelling_service = false;
+		// Already correct in an existing file → nothing to do. (A fresh profile has no file yet, so we
+		// still pre-seed it below so the very first launch honours the default/opt-in.)
+		if(existed && prefs.spellcheck.use_spelling_service === allowed) { return; }
+		prefs.spellcheck.use_spelling_service = allowed;
 		try { fs.mkdirSync(profileDir, {recursive: true}); } catch(e) {}
 		fs.writeFileSync(prefsPath, JSON.stringify(prefs));
 	} catch(e) {
-		try { console.error("[TiddlyDesktop] disableSpellingService failed:", e); } catch(_e) {}
+		try { console.error("[TiddlyDesktop] syncSpellingServicePref failed:", e); } catch(_e) {}
 	}
 };
 

--- a/source/js/utils/spellcheck.js
+++ b/source/js/utils/spellcheck.js
@@ -1,0 +1,66 @@
+/*
+Spellcheck helpers for TiddlyDesktop.
+
+Two deliberately separate concerns:
+
+1. disableSpellingService(profileDir) — runs from node-main BEFORE Chromium opens the profile.
+   NW.js turns Google's REMOTE "spelling service" (the kSpellCheckUseSpellingService preference) on by
+   default whenever --enable-spell-checking is set (see nwjs/nw.js#5129), which ships everything the
+   user types into an editor to Google for suggestions. We force that preference off in the Chromium
+   "Preferences" file so only the LOCAL Hunspell dictionary is ever used and no typed text leaves the
+   machine. Fail-safe and idempotent; re-applied every launch because Chromium rewrites Preferences on
+   shutdown. This covers every window (all share the one Chromium profile), including folder wikis.
+
+2. isEnabled($tw) / applyToDocument(doc, enabled) — the user-facing on/off toggle for LOCAL spellcheck
+   ($:/config/TiddlyDesktop/EnableSpellcheck, default "yes"). Chromium keeps --enable-spell-checking on
+   so the engine is always available; we gate the visible red squiggles per document via the inherited
+   `spellcheck` attribute on <html>. Editors that don't set their own attribute inherit it, so the
+   toggle takes effect on the next wiki (re)load with no app restart.
+*/
+
+"use strict";
+
+var CONFIG_TITLE = "$:/config/TiddlyDesktop/EnableSpellcheck";
+exports.CONFIG_TITLE = CONFIG_TITLE;
+
+// Force Chromium's remote (Google) spelling service off in the profile's Preferences file. profileDir
+// is the active profile dir (e.g. .../TiddlyDesktop/Default). Only safe to call while Chromium is not
+// running against that profile — i.e. from node-main, before the first window opens.
+exports.disableSpellingService = function(profileDir) {
+	var fs = require("fs"), path = require("path");
+	try {
+		if(!profileDir) { return; }
+		var prefsPath = path.join(profileDir, "Preferences"),
+			prefs = {},
+			existed = false;
+		try {
+			prefs = JSON.parse(fs.readFileSync(prefsPath, "utf8")) || {};
+			existed = true;
+		} catch(e) { prefs = {}; }
+		prefs.spellcheck = prefs.spellcheck || {};
+		// Already off in an existing file → nothing to do. (A fresh profile has no file yet, so we
+		// still pre-seed it below so the very first launch never enables the Google service.)
+		if(existed && prefs.spellcheck.use_spelling_service === false) { return; }
+		prefs.spellcheck.use_spelling_service = false;
+		try { fs.mkdirSync(profileDir, {recursive: true}); } catch(e) {}
+		fs.writeFileSync(prefsPath, JSON.stringify(prefs));
+	} catch(e) {
+		try { console.error("[TiddlyDesktop] disableSpellingService failed:", e); } catch(_e) {}
+	}
+};
+
+// Read the toggle from the backstage wiki. Defaults to enabled when unset or unreadable.
+exports.isEnabled = function($tw) {
+	try {
+		return $tw.wiki.getTiddlerText(CONFIG_TITLE, "yes") !== "no";
+	} catch(e) { return true; }
+};
+
+// Apply the toggle to a document by setting the inherited `spellcheck` attribute on <html>. Descendant
+// editors that don't set their own attribute inherit this, so squiggles switch on/off without a restart.
+exports.applyToDocument = function(doc, enabled) {
+	try {
+		if(!doc || !doc.documentElement) { return; }
+		doc.documentElement.setAttribute("spellcheck", enabled ? "true" : "false");
+	} catch(e) {}
+};

--- a/source/js/wiki-file-window.js
+++ b/source/js/wiki-file-window.js
@@ -6,6 +6,7 @@ Class for wiki file windows
 
 var windowBase = require("../js/window-base.js"),
 	hash = require("../js/utils/hash.js"),
+	spellcheck = require("../js/utils/spellcheck.js"),
 	fs = require("fs");
 
 // Constructor
@@ -223,6 +224,13 @@ WikiFileWindow.prototype.installEmbedsOnTiddlerWindows = function () {
 	setTimeout(tick, 0);
 };
 
+// Apply the current local-spellcheck setting to the wiki's iframe document. Safe to call any time.
+WikiFileWindow.prototype.applySpellcheck = function () {
+	try {
+		spellcheck.applyToDocument(this.iframe && this.iframe.contentDocument, spellcheck.isEnabled($tw));
+	} catch (e) {}
+};
+
 // Load handler for iframe
 WikiFileWindow.prototype.onloadiframe = function () {
 	var self = this;
@@ -244,6 +252,9 @@ WikiFileWindow.prototype.onloadiframe = function () {
 		});
 	}
 	self._iframeTeardowns = [];
+	// Apply the local-spellcheck toggle to this (re)loaded document. Runs on every load and can be
+	// re-run live via applySpellcheck() when the setting changes.
+	self.applySpellcheck();
 	if (!self._iframeCloseBound) {
 		self._iframeCloseBound = true;
 		self.window_nwjs.once("close", function () {

--- a/source/js/wiki-folder-main.js
+++ b/source/js/wiki-folder-main.js
@@ -48,6 +48,12 @@ var queryObject = $tw.desktop.utils.dom.decodeQueryString(
 	containerWindow.window.document.location,
 );
 
+// Apply the local-spellcheck toggle passed from the backstage. The Google spelling service is already
+// forced off profile-wide in node-main; this only gates the visible red squiggles for this folder wiki.
+try {
+	require("../js/utils/spellcheck.js").applyToDocument(document, queryObject.spellcheck !== "no");
+} catch (e) {}
+
 // First part of boot process
 require("../tiddlywiki/boot/bootprefix.js").bootprefix($tw);
 

--- a/source/js/wiki-folder-window.js
+++ b/source/js/wiki-folder-window.js
@@ -6,6 +6,7 @@ Class for wiki folder windows
 
 var windowBase = require("../js/window-base.js"),
 	hash = require("../js/utils/hash.js"),
+	spellcheck = require("../js/utils/spellcheck.js"),
 	fs = require("fs"),
 	path = require("path");
 
@@ -52,6 +53,7 @@ function WikiFolderWindow(options) {
 	$tw.desktop.gui.Window.open("html/wiki-folder-window.html?pathname=" + encodeURIComponent(this.pathname) + "&host=" + encodeURIComponent(host) + "&port=" + encodeURIComponent(port)
 			+ "&credentials=" + encodeURIComponent(credentials) + "&readers=" + encodeURIComponent(readers) + "&writers=" + encodeURIComponent(writers)
 			+ "&pathprefix=" + encodeURIComponent(pathPrefix) + "&roottiddler=" + encodeURIComponent(rootTiddler) + "&anonusername=" + encodeURIComponent(anonUsername) + "&gzip=" + encodeURIComponent(gzip)
+			+ "&spellcheck=" + encodeURIComponent(spellcheck.isEnabled($tw) ? "yes" : "no")
 			+ "&stateFile=" + encodeURIComponent(this.stateFile),this.applyGeometryToOpenOptions({
 		id: hash.simpleHash(this.getIdentifier()),
 		show: true,


### PR DESCRIPTION
spellcheck enabled the Google spellcheck service to run
This PR disables Google spellcheck service by default and lets users opt in to it