### PR TITLE
Android: attachments subfolders

### DIFF
--- a/TiddlyDesktopAndroid/app/src/main/assets/bridge/attach-subfolder.js
+++ b/TiddlyDesktopAndroid/app/src/main/assets/bridge/attach-subfolder.js
@@ -1,0 +1,60 @@
+/*
+ * Runs inside each wiki window. Defines window.__tdChooseSubfolder(): the shared "which subfolder
+ * of attachments/ should this file go into?" prompt used by both import paths (in-wiki drag/drop
+ * → attachments.js, and share-from-another-app → share-import.js).
+ *
+ * The choice is made in a NATIVE Android dialog (TDAttach.chooseSubfolder), so it works for the
+ * share flow too (which has no wiki JS driving it before the file is staged). The bridge call is
+ * asynchronous: it hands back a callback id, and Kotlin later invokes window.__tdAttachResolve.
+ *
+ * The last-used subfolder is remembered in $:/config/TiddlyDesktop/AttachmentsSubfolder so the
+ * dialog pre-fills it — the common case is one tap to accept, but it is always editable, and blank
+ * means the attachments/ root.
+ */
+(function () {
+	if (window.__tdChooseSubfolder) { return; }
+
+	var CONFIG = "$:/config/TiddlyDesktop/AttachmentsSubfolder";
+	var seq = 0, callbacks = {};
+
+	// Native → JS: Kotlin calls this with the callback id and a JSON result once the dialog closes.
+	window.__tdAttachResolve = function (id, json) {
+		var cb = callbacks[id];
+		if (!cb) { return; }
+		delete callbacks[id];
+		var res;
+		try { res = JSON.parse(json); } catch (e) { res = { status: "cancelled" }; }
+		cb(res);
+	};
+
+	function rememberedDefault() {
+		try { return ($tw.wiki.getTiddlerText(CONFIG, "") || "").trim(); } catch (e) { return ""; }
+	}
+	function remember(sub) {
+		try { $tw.wiki.addTiddler(new $tw.Tiddler({ title: CONFIG, text: sub || "" })); } catch (e) {}
+	}
+
+	// Returns a Promise resolving to the chosen subfolder ("" = attachments root), or null if the
+	// user cancelled. On a "saved" choice the value is remembered for next time.
+	window.__tdChooseSubfolder = function () {
+		return new Promise(function (resolve) {
+			if (typeof TDAttach === "undefined" || !TDAttach.chooseSubfolder) { resolve(""); return; }
+			var id = "sf" + (++seq);
+			callbacks[id] = function (res) {
+				if (res && res.status === "saved") {
+					var sub = typeof res.subfolder === "string" ? res.subfolder : "";
+					remember(sub);
+					resolve(sub);
+				} else {
+					resolve(null); // cancelled
+				}
+			};
+			try {
+				TDAttach.chooseSubfolder(rememberedDefault(), id);
+			} catch (e) {
+				delete callbacks[id];
+				resolve(""); // bridge unavailable → fall back to the attachments root
+			}
+		});
+	};
+})();

--- a/TiddlyDesktopAndroid/app/src/main/assets/bridge/attachments.js
+++ b/TiddlyDesktopAndroid/app/src/main/assets/bridge/attachments.js
@@ -54,18 +54,21 @@
 				var type = info.type || file.type || "application/octet-stream";
 				var reader = new FileReader();
 				reader.onload = function () {
-					var rel = "";
 					try {
 						var res = String(reader.result || "");
 						var comma = res.indexOf(",");
 						var b64 = comma >= 0 ? res.slice(comma + 1) : "";
-						rel = TDAttach.saveAttachment(b64, name, type);
-						if (rel) {
-							info.callback([{ title: name, type: type, "_canonical_uri": rel }]);
-						} else {
-							// Fall back to embedding the binary if the copy failed.
-							info.callback([{ title: name, type: type, text: b64 }]);
-						}
+						// Let the user choose which subfolder of attachments/ to save into first.
+						window.__tdChooseSubfolder().then(function (sub) {
+							if (sub === null) { info.callback([]); return; } // cancelled → import nothing
+							var rel = TDAttach.saveAttachment(b64, name, type, sub);
+							if (rel) {
+								info.callback([{ title: name, type: type, "_canonical_uri": rel }]);
+							} else {
+								// Fall back to embedding the binary if the copy failed.
+								info.callback([{ title: name, type: type, text: b64 }]);
+							}
+						});
 					} catch (e) {
 						info.callback([{ title: name, type: type }]);
 					}

--- a/TiddlyDesktopAndroid/app/src/main/assets/bridge/share-import.js
+++ b/TiddlyDesktopAndroid/app/src/main/assets/bridge/share-import.js
@@ -47,7 +47,7 @@
 
 	window.__tdImportShare = function (payloadJson) {
 		if (!payloadJson) { return; }
-		function go() {
+		(async function go() {
 			if (!(window.$tw && $tw.wiki && $tw.rootWidget)) { setTimeout(go, 200); return; }
 			try {
 				var fieldsList = JSON.parse(payloadJson);
@@ -56,37 +56,53 @@
 				var directAdded = false;   // media / text / link tiddlers added straight in
 				var importTiddlers = [];   // tiddler-container contents → native $:/Import flow
 
-				function importOne(fields) {
+				// Async: awaits the native subfolder chooser for the attachment branches.
+				async function importOne(fields) {
 					fields = JSON.parse(JSON.stringify(fields)); // clone
 					fields.title = uniqueTitle(fields.title || "shared");
 					var type = fields.type || "";
 					// A file staged natively (streamed to a temp file, not base64'd into the payload).
 					var staged = fields.__sharedFile;
 					if (staged != null) { delete fields.__sharedFile; }
+					function finishAdd() {
+						$tw.wiki.addTiddler(new $tw.Tiddler($tw.wiki.getCreationFields(), fields, $tw.wiki.getModificationFields()));
+						directAdded = true;
+						if (!firstTitle) { firstTitle = fields.title; }
+					}
 					if (staged && typeof TDAttach !== "undefined") {
 						if (type.indexOf("text/") === 0) {
 							// Shared text file → import its text.
 							fields.text = TDAttach.sharedFileText(staged);
-						} else if (extAttach) {
-							// Binary + External Attachments ON → attach (streamed into attachments/, kept external).
-							var rel = TDAttach.importSharedFile(staged, fields.title, type);
-							if (rel) { fields._canonical_uri = rel; }
-							else { fields.text = TDAttach.sharedFileBase64(staged); } // fallback: embed
-						} else {
-							// External Attachments OFF → import (embed) the file as base64.
-							fields.text = TDAttach.sharedFileBase64(staged);
+							finishAdd(); return;
 						}
-					} else {
-						// Legacy: base64 already in the payload (small files) — attach it if EA is on.
-						var isBinary = type && type.indexOf("text/") !== 0 && fields.text && !fields._canonical_uri;
-						if (isBinary && extAttach && typeof TDAttach !== "undefined") {
-							var rel2 = TDAttach.saveAttachment(fields.text, fields.title, type);
+						if (extAttach) {
+							// Binary + External Attachments ON → choose a subfolder, then stream it in (kept external).
+							var sub = await window.__tdChooseSubfolder();
+							if (sub === null) {
+								fields.text = TDAttach.sharedFileBase64(staged); // cancelled → embed (keep the shared file)
+							} else {
+								var rel = TDAttach.importSharedFile(staged, fields.title, type, sub);
+								if (rel) { fields._canonical_uri = rel; }
+								else { fields.text = TDAttach.sharedFileBase64(staged); } // fallback: embed
+							}
+							finishAdd(); return;
+						}
+						// External Attachments OFF → import (embed) the file as base64.
+						fields.text = TDAttach.sharedFileBase64(staged);
+						finishAdd(); return;
+					}
+					// Legacy: base64 already in the payload (small files) — attach it if EA is on.
+					var isBinary = type && type.indexOf("text/") !== 0 && fields.text && !fields._canonical_uri;
+					if (isBinary && extAttach && typeof TDAttach !== "undefined") {
+						var b64 = fields.text;
+						var sub2 = await window.__tdChooseSubfolder();
+						if (sub2 !== null) {
+							var rel2 = TDAttach.saveAttachment(b64, fields.title, type, sub2);
 							if (rel2) { delete fields.text; fields._canonical_uri = rel2; }
 						}
+						finishAdd(); return;
 					}
-					$tw.wiki.addTiddler(new $tw.Tiddler($tw.wiki.getCreationFields(), fields, $tw.wiki.getModificationFields()));
-					directAdded = true;
-					if (!firstTitle) { firstTitle = fields.title; }
+					finishAdd();
 				}
 
 				// A tiddler-container file (its text): deserialize into tiddlers via the type inferred
@@ -114,16 +130,17 @@
 					}
 				}
 
-				fieldsList.forEach(function (entry) {
+				for (var i = 0; i < fieldsList.length; i++) {
+					var entry = fieldsList[i];
 					if (entry && entry.__importText != null) {
 						importContainer(String(entry.__importText), entry.__importName || "");
 					} else if (entry && entry.__tid != null) {
 						// Legacy payload shape (older shares): a bare .tid.
 						importContainer(String(entry.__tid), "shared.tid");
 					} else {
-						importOne(entry);
+						await importOne(entry);
 					}
-				});
+				}
 				// Tiddler-container files → TiddlyWiki's native import: stage into $:/Import and show
 				// its review listing (name clashes, import filters, upgrades, confirm/cancel). On
 				// confirm the wiki saves itself, so we don't force a save here for these.
@@ -145,7 +162,6 @@
 			} catch (e) {
 				console.error("[TiddlyDesktop] share import failed:", e);
 			}
-		}
-		go();
+		})();
 	};
 })();

--- a/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/WikiActivity.kt
+++ b/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/WikiActivity.kt
@@ -102,7 +102,19 @@ class WikiActivity : ComponentActivity() {
     }
 
     /** Write a collab asset into this wiki's attachments/ folder; returns "./attachments/<name>". */
-    fun writeCollabAsset(base64: String, name: String): String = writeAttachment(base64, name)
+    /**
+     * Store a collab-received asset at the EXACT relative path the peer referenced (subfolders
+     * preserved), overwriting — the peer's _canonical_uri is fixed, so unlike a user import we must
+     * not bump the name or the [readAttachmentBytes] round-trip would miss.
+     */
+    fun writeCollabAsset(base64: String, name: String): String {
+        val bytes = android.util.Base64.decode(base64, android.util.Base64.DEFAULT)
+        val rel = sanitizeAttachmentRel(name).ifBlank { "attachment" }
+        val target = File(attachmentsDir() ?: error("no folder for attachments"), rel)
+        target.parentFile?.mkdirs()
+        target.writeBytes(bytes)
+        return "./attachments/$rel"
+    }
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -183,6 +195,7 @@ class WikiActivity : ComponentActivity() {
                     injectAsset(view, "bridge/no-save-notify.js")
                     injectAsset(view, "bridge/wiki-ux.js") // print / fullscreen hooks
                     injectAsset(view, "bridge/pinch-zoom.js") // allow pinch-zoom on single-file wikis
+                    injectAsset(view, "bridge/attach-subfolder.js") // shared subfolder chooser (window.__tdChooseSubfolder)
                     injectAsset(view, "bridge/attachments.js") // external-attachments import hook
                     injectAsset(view, "bridge/embeds.js") // harden allowlisted media embeds (YouTube, …)
                     injectAsset(view, "bridge/pdf-viewer.js") // inline PDF via pdf.js (WebView has no PDF plugin)
@@ -535,11 +548,31 @@ class WikiActivity : ComponentActivity() {
 
     /** JS-facing bridge: the external-attachments import hook copies files here. */
     inner class WikiAttachBridge {
-        /** Returns "./attachments/<name>" for the _canonical_uri, or "" on failure. */
+        /** Returns "./attachments/[<subfolder>/]<name>" for the _canonical_uri, or "" on failure. */
         @android.webkit.JavascriptInterface
-        fun saveAttachment(base64: String, filename: String, mime: String): String =
-            runCatching { writeAttachment(base64, filename) }
+        fun saveAttachment(base64: String, filename: String, mime: String, subfolder: String): String =
+            runCatching { writeAttachment(base64, filename, subfolder) }
                 .getOrElse { Log.w(TAG, "saveAttachment failed: ${it.message}"); "" }
+
+        /**
+         * Show the native "which subfolder of attachments/?" chooser for an import, pre-filled with
+         * [defaultSub] and offering the wiki's existing subfolders as quick-picks. Asynchronous: the
+         * result is delivered back to JS via window.__tdAttachResolve([callbackId], json), where json
+         * is {"status":"saved","subfolder":"..."} (blank = attachments root) or {"status":"cancelled"}.
+         */
+        @android.webkit.JavascriptInterface
+        fun chooseSubfolder(defaultSub: String, callbackId: String) = runOnUiThread {
+            promptSubfolder(defaultSub) { chosen ->
+                val json = if (chosen == null) {
+                    org.json.JSONObject(mapOf("status" to "cancelled")).toString()
+                } else {
+                    org.json.JSONObject(mapOf("status" to "saved", "subfolder" to chosen)).toString()
+                }
+                webView.evaluateJavascript(
+                    "window.__tdAttachResolve && window.__tdAttachResolve(${jsQuote(callbackId)},${jsQuote(json)});", null
+                )
+            }
+        }
 
         /**
          * Attach a shared file staged by MainActivity (share-import.js, External Attachments ON):
@@ -547,17 +580,19 @@ class WikiActivity : ComponentActivity() {
          * (video) works. Deletes the temp on success. Returns "./attachments/<name>" or "".
          */
         @android.webkit.JavascriptInterface
-        fun importSharedFile(tempPath: String, filename: String, mime: String): String =
+        fun importSharedFile(tempPath: String, filename: String, mime: String, subfolder: String): String =
             runCatching {
                 val src = File(tempPath)
                 if (!src.exists()) return ""
-                val dir = attachmentsDir()?.apply { mkdirs() } ?: error("no folder for attachments")
+                val sub = sanitizeAttachmentRel(subfolder)
+                val dir = (attachmentsDir()?.let { if (sub.isEmpty()) it else File(it, sub) })
+                    ?.apply { mkdirs() } ?: error("no folder for attachments")
                 val safe = sanitizeAttachmentName(filename)
                 var name = safe; var n = 1
                 while (File(dir, name).exists()) { name = bump(safe, n++) }
                 src.inputStream().use { i -> File(dir, name).outputStream().use { o -> i.copyTo(o) } }
                 runCatching { src.delete() }
-                "./attachments/$name"
+                if (sub.isEmpty()) "./attachments/$name" else "./attachments/$sub/$name"
             }.getOrElse { Log.w(TAG, "importSharedFile failed: ${it.message}"); "" }
 
         /** Base64 of a staged shared file (embed/import when External Attachments is OFF). "" on failure. */
@@ -601,21 +636,27 @@ class WikiActivity : ComponentActivity() {
         return File(base, "attachments")
     }
 
-    private fun writeAttachment(base64: String, filename: String): String {
+    private fun writeAttachment(base64: String, filename: String, subfolder: String): String {
         val bytes = android.util.Base64.decode(base64, android.util.Base64.DEFAULT)
-        val safe = sanitizeAttachmentName(filename)
-        val dir = attachmentsDir()?.apply { mkdirs() } ?: error("no folder for attachments")
-        var name = safe; var n = 1
-        while (File(dir, name).exists()) { name = bump(safe, n++) }
+        val leaf = sanitizeAttachmentName(filename)
+        val sub = sanitizeAttachmentRel(subfolder)   // "" = attachments root
+        val dir = (attachmentsDir()?.let { if (sub.isEmpty()) it else File(it, sub) })
+            ?.apply { mkdirs() } ?: error("no folder for attachments")
+        var name = leaf; var n = 1
+        while (File(dir, name).exists()) { name = bump(leaf, n++) }
         File(dir, name).writeBytes(bytes)
-        return "./attachments/$name"
+        return if (sub.isEmpty()) "./attachments/$name" else "./attachments/$sub/$name"
     }
 
     /** Read a stored attachment's raw bytes from the wiki's attachments/ folder (null if absent). */
     fun readAttachmentBytes(name: String): ByteArray? = runCatching {
-        val dir = attachmentsDir() ?: return@runCatching null
-        val f = File(dir, sanitizeAttachmentName(name))
-        if (f.exists()) f.readBytes() else null
+        val root = attachmentsDir() ?: return@runCatching null
+        val rel = sanitizeAttachmentRel(name)
+        if (rel.isEmpty()) return@runCatching null
+        val f = File(root, rel)
+        // Keep the read inside attachments/ (rel is already segment-sanitized, but be explicit).
+        if (!f.canonicalPath.startsWith(root.canonicalPath + File.separator)) return@runCatching null
+        if (f.isFile) f.readBytes() else null
     }.getOrNull()
 
 
@@ -623,9 +664,82 @@ class WikiActivity : ComponentActivity() {
         name.substringAfterLast('/').substringAfterLast('\\').replace(Regex("[^A-Za-z0-9._-]"), "_")
             .ifBlank { "attachment" }
 
+    /**
+     * Sanitize a relative attachments path per segment, KEEPING subfolder structure; drops empty,
+     * "." and ".." segments so it can never escape attachments/. "" means the attachments root.
+     */
+    private fun sanitizeAttachmentRel(rel: String): String =
+        rel.replace('\\', '/').split('/')
+            .map { it.replace(Regex("[^A-Za-z0-9._-]"), "_") }
+            .filter { it.isNotBlank() && it != "." && it != ".." }
+            .joinToString("/")
+
+    /** Existing subfolders under attachments/ (relative, forward-slash), for the chooser's quick-picks. */
+    private fun existingAttachmentSubfolders(): List<String> {
+        val root = attachmentsDir() ?: return emptyList()
+        if (!root.isDirectory) return emptyList()
+        return root.walkTopDown()
+            .filter { it.isDirectory && it != root }
+            .map { it.relativeTo(root).path.replace('\\', '/') }
+            .sorted().take(50).toList()
+    }
+
     private fun bump(name: String, n: Int): String {
         val dot = name.lastIndexOf('.')
         return if (dot > 0) "${name.substring(0, dot)}-$n${name.substring(dot)}" else "$name-$n"
+    }
+
+    /**
+     * Native subfolder chooser for an attachment import. Pre-fills [defaultSub], offers existing
+     * subfolders as tap-to-fill quick-picks, and calls [onResult] with the sanitized subfolder
+     * ("" = attachments root) or null when the user cancels.
+     */
+    private fun promptSubfolder(defaultSub: String, onResult: (String?) -> Unit) {
+        val density = resources.displayMetrics.density
+        fun dp(v: Int) = (v * density).toInt()
+
+        val input = android.widget.EditText(this).apply {
+            setText(defaultSub)
+            setSelection(text.length)
+            hint = getString(R.string.attach_folder_hint)
+            isSingleLine = true
+            inputType = android.text.InputType.TYPE_CLASS_TEXT or android.text.InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+        }
+        val message = android.widget.TextView(this).apply {
+            text = getString(R.string.attach_folder_message)
+            setPadding(0, 0, 0, dp(8))
+        }
+        val container = android.widget.LinearLayout(this).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            setPadding(dp(20), dp(12), dp(20), 0)
+            addView(message)
+            addView(input)
+        }
+        existingAttachmentSubfolders().takeIf { it.isNotEmpty() }?.let { subs ->
+            val row = android.widget.LinearLayout(this).apply { orientation = android.widget.LinearLayout.HORIZONTAL }
+            subs.forEach { sub ->
+                row.addView(android.widget.Button(this).apply {
+                    text = sub
+                    isAllCaps = false
+                    setOnClickListener { input.setText(sub); input.setSelection(sub.length) }
+                })
+            }
+            container.addView(android.widget.HorizontalScrollView(this).apply {
+                setPadding(0, dp(8), 0, 0); addView(row)
+            })
+        }
+
+        var settled = false
+        fun finish(result: String?) { if (!settled) { settled = true; onResult(result) } }
+
+        android.app.AlertDialog.Builder(this)
+            .setTitle(R.string.attach_folder_title)
+            .setView(container)
+            .setCancelable(true)
+            .setPositiveButton(R.string.attach_folder_save) { _, _ -> finish(sanitizeAttachmentRel(input.text.toString())) }
+            .setNegativeButton(android.R.string.cancel) { _, _ -> finish(null) }
+            .setOnCancelListener { finish(null) }
+            .show()
     }
 
 

--- a/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/collab/CollabBridge.kt
+++ b/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/collab/CollabBridge.kt
@@ -297,7 +297,8 @@ class CollabBridge(
     /** If [path] is a wiki-relative attachments reference, its decoded file name; else null. */
     private fun attachmentName(path: String): String? {
         val p = path.removePrefix("./")
-        return if (p.startsWith("attachments/")) Uri.decode(p.substringAfterLast('/')) else null
+        // Keep the full sub-path under attachments/ (subfolders preserved), not just the basename.
+        return if (p.startsWith("attachments/")) Uri.decode(p.removePrefix("attachments/")).ifBlank { null } else null
     }
 
     private fun openOut(path: String): java.io.OutputStream =

--- a/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/server/SingleFileWikiServer.kt
+++ b/TiddlyDesktopAndroid/app/src/main/java/com/tiddlywiki/tiddlydesktop/server/SingleFileWikiServer.kt
@@ -280,7 +280,9 @@ class SingleFileWikiServer(
      * positioning (InputStream.skip is O(n) for SAF streams).
      */
     private fun serveAttachment(output: OutputStream, name: String, headers: Map<String, String>, headOnly: Boolean) {
-        if (name.isBlank() || name.contains('/') || name.contains("..")) { sendError(output, 404, "Not Found"); return }
+        // Subfolders under attachments/ are allowed ("sub/dir/file.png"); reject anything that could
+        // escape the folder — an absolute/empty/"."/".." segment (covers leading, trailing and double slashes).
+        if (name.isBlank() || name.split('/').any { it.isEmpty() || it == "." || it == ".." }) { sendError(output, 404, "Not Found"); return }
         val target = resolveAttachment(name)
         if (target == null) { sendError(output, 404, "Not Found"); return }
         val (fileUri, total) = target
@@ -326,16 +328,26 @@ class SingleFileWikiServer(
         }
     }
 
-    /** Locate an attachment in `<containing folder>/attachments/<name>`; returns (uri, length). */
+    /**
+     * Locate an attachment in `<containing folder>/attachments/<name>`, where `name` may include
+     * subfolder segments ("sub/dir/file.png"); returns (uri, length). Caller has already rejected
+     * traversal segments.
+     */
     private fun resolveAttachment(name: String): Pair<Uri, Long>? = runCatching {
         val folder = backupDirUri?.ifBlank { null } ?: return null
         if (folder.startsWith("content://")) {
             val root = DocumentFile.fromTreeUri(context, Uri.parse(folder)) ?: return null
-            val f = root.findFile("attachments")?.findFile(name) ?: return null
+            // Walk each path segment so subfolders resolve (SAF has no path-based lookup).
+            var f = root.findFile("attachments") ?: return null
+            for (seg in name.split('/')) { f = f.findFile(seg) ?: return null }
+            if (!f.isFile) return null
             f.uri to f.length()
         } else {
-            val f = File(File(folder, "attachments"), name)
-            if (!f.exists()) return null
+            val base = File(folder, "attachments")
+            val f = File(base, name)
+            // Belt-and-braces: ensure the resolved path stays inside the attachments folder.
+            if (!f.canonicalPath.startsWith(base.canonicalPath + File.separator)) return null
+            if (!f.isFile) return null
             Uri.fromFile(f) to f.length()
         }
     }.getOrNull()

--- a/TiddlyDesktopAndroid/app/src/main/res/values/strings.xml
+++ b/TiddlyDesktopAndroid/app/src/main/res/values/strings.xml
@@ -76,5 +76,10 @@
 
     <!-- External Attachments: note that absolute-path options don't apply on Android. -->
     <string name="ea_note_caption">External Attachments (Android)</string>
-    <string name="ea_note_body">On Android, imported attachments are always copied into this wiki\'s attachments/ folder and linked by a relative path. The absolute-path options have no effect here — folders shared via Android (content://) have no filesystem path.</string>
+    <string name="ea_note_body">On Android, imported attachments are copied into this wiki\'s attachments/ folder (you can choose a subfolder on import) and linked by a relative path. The absolute-path options have no effect here — folders shared via Android (content://) have no filesystem path.</string>
+    <!-- Subfolder chooser shown on each attachment import -->
+    <string name="attach_folder_title">Save attachment to</string>
+    <string name="attach_folder_message">Choose a subfolder inside attachments/ (leave blank to use the attachments root).</string>
+    <string name="attach_folder_hint">Subfolder</string>
+    <string name="attach_folder_save">Save</string>
 </resources>


### PR DESCRIPTION
Now choosing subfolders for Android attachments in the `attachments` directory is possible